### PR TITLE
clock@schorschii: Always smooth hour hand

### DIFF
--- a/clock@schorschii/files/clock@schorschii/desklet.js
+++ b/clock@schorschii/files/clock@schorschii/desklet.js
@@ -93,15 +93,13 @@ MyDesklet.prototype = {
 		let mseconds = this._displayTime.get_microsecond();
 
 		// calc pointer rotation angles
-		let hours_deg = 0;
+		let hours_deg = ((hours+(minutes/60))*360/12);
 		let minutes_deg = 0;
 		let seconds_deg = 0;
 		if (this.smooth_seconds_hand == true) {
-			hours_deg = ((hours+(minutes/60))*360/12);
 			minutes_deg = ((minutes+(seconds/60))*360/60);
 			seconds_deg = ((seconds+(mseconds/1000000))*360/60);
 		} else {
-			hours_deg = (hours*360/12);
 			minutes_deg = (minutes*360/60);
 			seconds_deg = (seconds*360/60);
 		}

--- a/clock@schorschii/files/clock@schorschii/desklet.js
+++ b/clock@schorschii/files/clock@schorschii/desklet.js
@@ -50,6 +50,7 @@ MyDesklet.prototype = {
 		this.settings.bindProperty(Settings.BindingDirection.IN, "desklet-size", "desklet_size", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "show-seconds-hand", "show_seconds_hand", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "smooth-seconds-hand", "smooth_seconds_hand", this.on_setting_changed);
+		this.settings.bindProperty(Settings.BindingDirection.IN, "smooth-minutes-hand", "smooth_minutes_hand", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "hide-decorations", "hide_decorations", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "use-custom-label", "use_custom_label", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "custom-label", "custom_label", this.on_setting_changed);
@@ -97,11 +98,14 @@ MyDesklet.prototype = {
 		let minutes_deg = 0;
 		let seconds_deg = 0;
 		if (this.smooth_seconds_hand == true) {
-			minutes_deg = ((minutes+(seconds/60))*360/60);
 			seconds_deg = ((seconds+(mseconds/1000000))*360/60);
 		} else {
-			minutes_deg = (minutes*360/60);
 			seconds_deg = (seconds*360/60);
+		}
+		if (this.smooth_minutes_hand == true) {
+			minutes_deg = ((minutes+(seconds/60))*360/60);
+		} else {
+			minutes_deg = (minutes*360/60);
 		}
 
 		// rotate pointer graphics

--- a/clock@schorschii/files/clock@schorschii/po/clock@schorschii.pot
+++ b/clock@schorschii/files/clock@schorschii/po/clock@schorschii.pot
@@ -1,46 +1,52 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# ANALOG CHRONOMETER TRANSLATIONS.
+# Copyright (C) 2017 FULL NAME
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-26 17:40+0800\n"
+"Project-Id-Version: Analog Chronometer VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2017-05-04 18:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: \n"
 
-#: desklet.js:178
+#: desklet.js:190
 msgid "Clock"
-msgstr ""
-
-#. clock@schorschii->metadata.json->description
-msgid ""
-"A scaleable analog clock desklet with smooth hands and free choice of "
-"images."
-msgstr ""
-
-#. clock@schorschii->metadata.json->name
-msgid "Analog Chronometer"
 msgstr ""
 
 #. clock@schorschii->settings-schema.json->head3->description
 msgid "Timezone"
 msgstr ""
 
-#. clock@schorschii->settings-schema.json->hide-decorations->description
-msgid "Hide decorations"
+#. clock@schorschii->settings-schema.json->style->description
+msgid "Clock style"
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->style->tooltip
+msgid "Select the background graphic you would like to use."
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Dark"
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Light"
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Custom"
 msgstr ""
 
 #. clock@schorschii->settings-schema.json->head4->description
-msgid "Custom images"
+msgid "Custom images (available if clock style is set to 'custom')"
 msgstr ""
 
 #. clock@schorschii->settings-schema.json->desklet-size->description
@@ -64,25 +70,31 @@ msgid "Visual"
 msgstr ""
 
 #. clock@schorschii->settings-schema.json->smooth-seconds-hand->description
-msgid "Smooth hands"
+msgid "Smooth second hand"
 msgstr ""
 
 #. clock@schorschii->settings-schema.json->smooth-seconds-hand->tooltip
 msgid ""
-"Use smooth animation for hour, minute and seconds hand instead of refreshing"
-" it only every second."
+"Use smooth animation for seconds hand instead of refreshing it only every "
+"second."
 msgstr ""
 
 #. clock@schorschii->settings-schema.json->head0->description
 msgid "Settings for clock@schorschii"
 msgstr ""
 
-#. clock@schorschii->settings-schema.json->img-bg->description
-msgid "Background"
+#. clock@schorschii->settings-schema.json->img-h->description
+msgid "Hour hand"
 msgstr ""
 
-#. clock@schorschii->settings-schema.json->img-bg->tooltip
-msgid "Choose your own background image."
+#. clock@schorschii->settings-schema.json->img-h->tooltip
+msgid ""
+"Choose your own image for the hour hand. Should be as big as the background "
+"image."
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->hide-decorations->description
+msgid "Hide decorations"
 msgstr ""
 
 #. clock@schorschii->settings-schema.json->img-m->description
@@ -93,6 +105,14 @@ msgstr ""
 msgid ""
 "Choose your own image for the minute hand. Should be as big as the "
 "background image."
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->img-bg->description
+msgid "Background"
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->img-bg->tooltip
+msgid "Choose your own background image."
 msgstr ""
 
 #. clock@schorschii->settings-schema.json->img-s->description
@@ -148,30 +168,21 @@ msgid ""
 "unavailable unless the checkbox above is enabled."
 msgstr ""
 
-#. clock@schorschii->settings-schema.json->img-h->description
-msgid "Hour hand"
+#. clock@schorschii->settings-schema.json->smooth-minutes-hand->description
+msgid "Smooth minute hand"
 msgstr ""
 
-#. clock@schorschii->settings-schema.json->img-h->tooltip
+#. clock@schorschii->settings-schema.json->smooth-minutes-hand->tooltip
 msgid ""
-"Choose your own image for the hour hand. Should be as big as the background "
-"image."
+"Use smooth animation for minute hand instead of moving it only once per "
+"minute."
 msgstr ""
 
-msgid "Clock style"
+#. clock@schorschii->metadata.json->description
+msgid ""
+"A scaleable analog clock desklet with smooth hands and free choice of images."
 msgstr ""
 
-msgid "Custom images (available if clock style is set to 'custom')"
-msgstr ""
-
-#. Clock design - light
-msgid "Light"
-msgstr ""
-
-#. Clock design - dark
-msgid "Dark"
-msgstr ""
-
-#. Clock design - use custom images
-msgid "Custom"
+#. clock@schorschii->metadata.json->name
+msgid "Analog Chronometer"
 msgstr ""

--- a/clock@schorschii/files/clock@schorschii/po/de.po
+++ b/clock@schorschii/files/clock@schorschii/po/de.po
@@ -6,44 +6,51 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-30 15:31+0200\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2017-05-04 17:55+0100\n"
 "PO-Revision-Date: 2017-04-30 15:42+0200\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
-#: desklet.js:178
+#: desklet.js:190
 msgid "Clock"
 msgstr "Uhr"
-
-#. clock@schorschii->metadata.json->description
-msgid ""
-"A scaleable analog clock desklet with smooth hands and free choice of images."
-msgstr ""
-"Ein skalierbares Analoguhr-Desklet mit weich laufendem Sekundenzeiger und "
-"freier Grafikauswahl."
-
-#. clock@schorschii->metadata.json->name
-msgid "Analog Chronometer"
-msgstr "Analoges Chronometer"
 
 #. clock@schorschii->settings-schema.json->head3->description
 msgid "Timezone"
 msgstr "Zeitzone"
 
-#. clock@schorschii->settings-schema.json->hide-decorations->description
-msgid "Hide decorations"
-msgstr "Dekorationen verstecken"
+#. clock@schorschii->settings-schema.json->style->description
+msgid "Clock style"
+msgstr "Uhrdesign"
+
+#. clock@schorschii->settings-schema.json->style->tooltip
+msgid "Select the background graphic you would like to use."
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Dark"
+msgstr "Dunkel"
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Light"
+msgstr "Hell"
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Custom"
+msgstr "Eigene Bilder verwenden"
 
 #. clock@schorschii->settings-schema.json->head4->description
-msgid "Custom images"
-msgstr "Benutzerdefinierte Grafiken"
+msgid "Custom images (available if clock style is set to 'custom')"
+msgstr ""
+"Eigene Grafiken (werden verwendet wenn das Design auf 'Eigene Bilder "
+"verwendet' gesetzt ist)"
 
 #. clock@schorschii->settings-schema.json->desklet-size->description
 msgid "Desklet size"
@@ -66,13 +73,15 @@ msgid "Visual"
 msgstr "Optische Einstellungen"
 
 #. clock@schorschii->settings-schema.json->smooth-seconds-hand->description
-msgid "Smooth hands"
-msgstr "Weiche Zeiger verwenden"
+#, fuzzy
+msgid "Smooth second hand"
+msgstr "Zeige Sekundenzeiger"
 
 #. clock@schorschii->settings-schema.json->smooth-seconds-hand->tooltip
+#, fuzzy
 msgid ""
-"Use smooth animation for hour, minute and seconds hand instead of refreshing "
-"it only every second."
+"Use smooth animation for seconds hand instead of refreshing it only every "
+"second."
 msgstr ""
 "Zeige weiche Zeigeranimation, anstatt nur jede Sekunde zu aktualisieren."
 
@@ -80,13 +89,21 @@ msgstr ""
 msgid "Settings for clock@schorschii"
 msgstr "Einstellungen für clock@schorschii"
 
-#. clock@schorschii->settings-schema.json->img-bg->description
-msgid "Background"
-msgstr "Hintergrund"
+#. clock@schorschii->settings-schema.json->img-h->description
+msgid "Hour hand"
+msgstr "Stundenzeiger"
 
-#. clock@schorschii->settings-schema.json->img-bg->tooltip
-msgid "Choose your own background image."
-msgstr "Wählen Sie Ihre eigenes Ziffernblatt."
+#. clock@schorschii->settings-schema.json->img-h->tooltip
+msgid ""
+"Choose your own image for the hour hand. Should be as big as the background "
+"image."
+msgstr ""
+"Wählen Sie Ihr eigenes Bild für den Stundenzeiger. Es sollte genau so groß "
+"sein, wie das Hintergrundbild."
+
+#. clock@schorschii->settings-schema.json->hide-decorations->description
+msgid "Hide decorations"
+msgstr "Dekorationen verstecken"
 
 #. clock@schorschii->settings-schema.json->img-m->description
 msgid "Minute hand"
@@ -99,6 +116,14 @@ msgid ""
 msgstr ""
 "Wählen Sie Ihr eigenes Bild für den Minutenzeiger. Es sollte genau so groß "
 "sein, wie das Hintergrundbild."
+
+#. clock@schorschii->settings-schema.json->img-bg->description
+msgid "Background"
+msgstr "Hintergrund"
+
+#. clock@schorschii->settings-schema.json->img-bg->tooltip
+msgid "Choose your own background image."
+msgstr "Wählen Sie Ihre eigenes Ziffernblatt."
 
 #. clock@schorschii->settings-schema.json->img-s->description
 msgid "Seconds hand"
@@ -160,32 +185,29 @@ msgstr ""
 "Legen Sie hier Ihr eigenes Desklet-Label fest, z.B. um mehrere Zeitzonen "
 "anzuzeigen. Sie müssen zuerst den Schalter darüber einschalten."
 
-#. clock@schorschii->settings-schema.json->img-h->description
-msgid "Hour hand"
-msgstr "Stundenzeiger"
+#. clock@schorschii->settings-schema.json->smooth-minutes-hand->description
+#, fuzzy
+msgid "Smooth minute hand"
+msgstr "Weiche Zeiger verwenden"
 
-#. clock@schorschii->settings-schema.json->img-h->tooltip
+#. clock@schorschii->settings-schema.json->smooth-minutes-hand->tooltip
+#, fuzzy
 msgid ""
-"Choose your own image for the hour hand. Should be as big as the background "
-"image."
+"Use smooth animation for minute hand instead of moving it only once per "
+"minute."
 msgstr ""
-"Wählen Sie Ihr eigenes Bild für den Stundenzeiger. Es sollte genau so groß "
-"sein, wie das Hintergrundbild."
+"Zeige weiche Zeigeranimation, anstatt nur jede Sekunde zu aktualisieren."
 
-msgid "Clock style"
-msgstr "Uhrdesign"
+#. clock@schorschii->metadata.json->description
+msgid ""
+"A scaleable analog clock desklet with smooth hands and free choice of images."
+msgstr ""
+"Ein skalierbares Analoguhr-Desklet mit weich laufendem Sekundenzeiger und "
+"freier Grafikauswahl."
 
-msgid "Custom images (available if clock style is set to 'custom')"
-msgstr "Eigene Grafiken (werden verwendet wenn das Design auf 'Eigene Bilder verwendet' gesetzt ist)"
+#. clock@schorschii->metadata.json->name
+msgid "Analog Chronometer"
+msgstr "Analoges Chronometer"
 
-#. Clock design - light
-msgid "Light"
-msgstr "Hell"
-
-#. Clock design - dark
-msgid "Dark"
-msgstr "Dunkel"
-
-#. Clock design - use custom images
-msgid "Custom"
-msgstr "Eigene Bilder verwenden"
+#~ msgid "Custom images"
+#~ msgstr "Benutzerdefinierte Grafiken"

--- a/clock@schorschii/files/clock@schorschii/po/zh_CN.po
+++ b/clock@schorschii/files/clock@schorschii/po/zh_CN.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-02 01:40+0800\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2017-05-04 17:55+0100\n"
 "PO-Revision-Date: 2017-05-02 01:43+0800\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,30 +18,37 @@ msgstr ""
 "X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: desklet.js:178
+#: desklet.js:190
 msgid "Clock"
 msgstr "时钟"
-
-#. clock@schorschii->metadata.json->description
-msgid ""
-"A scaleable analog clock desklet with smooth hands and free choice of images."
-msgstr "一个可以使用平滑指针和自由选择图片的可扩展的模拟时钟桌面小工具。"
-
-#. clock@schorschii->metadata.json->name
-msgid "Analog Chronometer"
-msgstr "模拟天文钟"
 
 #. clock@schorschii->settings-schema.json->head3->description
 msgid "Timezone"
 msgstr "时区"
 
-#. clock@schorschii->settings-schema.json->hide-decorations->description
-msgid "Hide decorations"
-msgstr "隐藏装饰"
+#. clock@schorschii->settings-schema.json->style->description
+msgid "Clock style"
+msgstr "时钟风格"
+
+#. clock@schorschii->settings-schema.json->style->tooltip
+msgid "Select the background graphic you would like to use."
+msgstr ""
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Dark"
+msgstr "黑色"
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Light"
+msgstr "浅色"
+
+#. clock@schorschii->settings-schema.json->style->options
+msgid "Custom"
+msgstr "自定义"
 
 #. clock@schorschii->settings-schema.json->head4->description
-msgid "Custom images"
-msgstr "自定义图片"
+msgid "Custom images (available if clock style is set to 'custom')"
+msgstr "自定义图片（时钟风格设置为‘自定义’时可用）"
 
 #. clock@schorschii->settings-schema.json->desklet-size->description
 msgid "Desklet size"
@@ -64,26 +71,34 @@ msgid "Visual"
 msgstr "视觉"
 
 #. clock@schorschii->settings-schema.json->smooth-seconds-hand->description
-msgid "Smooth hands"
-msgstr "平滑指针"
+#, fuzzy
+msgid "Smooth second hand"
+msgstr "显示秒针"
 
 #. clock@schorschii->settings-schema.json->smooth-seconds-hand->tooltip
+#, fuzzy
 msgid ""
-"Use smooth animation for hour, minute and seconds hand instead of refreshing "
-"it only every second."
+"Use smooth animation for seconds hand instead of refreshing it only every "
+"second."
 msgstr "使用时针、分针和秒针的平滑动画效果而不是每秒刷新。"
 
 #. clock@schorschii->settings-schema.json->head0->description
 msgid "Settings for clock@schorschii"
 msgstr "clock@schorschii的设置"
 
-#. clock@schorschii->settings-schema.json->img-bg->description
-msgid "Background"
-msgstr "背景"
+#. clock@schorschii->settings-schema.json->img-h->description
+msgid "Hour hand"
+msgstr "时针"
 
-#. clock@schorschii->settings-schema.json->img-bg->tooltip
-msgid "Choose your own background image."
-msgstr "选择您的背景图片。"
+#. clock@schorschii->settings-schema.json->img-h->tooltip
+msgid ""
+"Choose your own image for the hour hand. Should be as big as the background "
+"image."
+msgstr "选择您自己的时针图片。应当和背景图片一样大。"
+
+#. clock@schorschii->settings-schema.json->hide-decorations->description
+msgid "Hide decorations"
+msgstr "隐藏装饰"
 
 #. clock@schorschii->settings-schema.json->img-m->description
 msgid "Minute hand"
@@ -94,6 +109,14 @@ msgid ""
 "Choose your own image for the minute hand. Should be as big as the "
 "background image."
 msgstr "选择您自己的分针图片。应当和背景图片一样大。"
+
+#. clock@schorschii->settings-schema.json->img-bg->description
+msgid "Background"
+msgstr "背景"
+
+#. clock@schorschii->settings-schema.json->img-bg->tooltip
+msgid "Choose your own background image."
+msgstr "选择您的背景图片。"
 
 #. clock@schorschii->settings-schema.json->img-s->description
 msgid "Seconds hand"
@@ -150,33 +173,29 @@ msgstr ""
 "在这里设置您的自定义标签，例如用于多个时区。除非启用了以上复选框，否则无法使"
 "用这个输入框。"
 
-#. clock@schorschii->settings-schema.json->img-h->description
-msgid "Hour hand"
-msgstr "时针"
+#. clock@schorschii->settings-schema.json->smooth-minutes-hand->description
+#, fuzzy
+msgid "Smooth minute hand"
+msgstr "平滑指针"
 
-#. clock@schorschii->settings-schema.json->img-h->tooltip
+#. clock@schorschii->settings-schema.json->smooth-minutes-hand->tooltip
+#, fuzzy
 msgid ""
-"Choose your own image for the hour hand. Should be as big as the background "
-"image."
-msgstr "选择您自己的时针图片。应当和背景图片一样大。"
+"Use smooth animation for minute hand instead of moving it only once per "
+"minute."
+msgstr "使用时针、分针和秒针的平滑动画效果而不是每秒刷新。"
 
-msgid "Clock style"
-msgstr "时钟风格"
+#. clock@schorschii->metadata.json->description
+msgid ""
+"A scaleable analog clock desklet with smooth hands and free choice of images."
+msgstr "一个可以使用平滑指针和自由选择图片的可扩展的模拟时钟桌面小工具。"
 
-msgid "Custom images (available if clock style is set to 'custom')"
-msgstr "自定义图片（时钟风格设置为‘自定义’时可用）"
+#. clock@schorschii->metadata.json->name
+msgid "Analog Chronometer"
+msgstr "模拟天文钟"
 
-#. Clock design - light
-msgid "Light"
-msgstr "浅色"
-
-#. Clock design - dark
-msgid "Dark"
-msgstr "黑色"
-
-#. Clock design - use custom images
-msgid "Custom"
-msgstr "自定义"
+#~ msgid "Custom images"
+#~ msgstr "自定义图片"
 
 #~ msgid "Settings for clock@schorschii   (Version 1.1)"
 #~ msgstr "clock@schorschii的设置（版本1.1）"

--- a/clock@schorschii/files/clock@schorschii/settings-schema.json
+++ b/clock@schorschii/files/clock@schorschii/settings-schema.json
@@ -27,8 +27,14 @@
     },
     "smooth-seconds-hand": {
         "type": "checkbox",
-        "description": "Smooth hands",
-        "tooltip": "Use smooth animation for hour, minute and seconds hand instead of refreshing it only every second.",
+        "description": "Smooth second hand",
+        "tooltip": "Use smooth animation for seconds hand instead of refreshing it only every second.",
+        "default": true
+    },
+    "smooth-minutes-hand": {
+        "type": "checkbox",
+        "description": "Smooth minute hand",
+        "tooltip": "Use smooth animation for minute hand instead of moving it only once per minute.",
         "default": true
     },
     "hide-decorations": {


### PR DESCRIPTION
The hour hand of an analogue clock should always indicate partial elapsed hours, even when seconds and minutes are not 'smoothed'. At 9:55 the hour hand should not point at 270° straight to the nine. We are so used to this that if it is not smoothed then close to the hour it easy to glance at the clock and see it as 8:55. I've checked all the clocks I can find, both real and virtual. Smoothing the hour is always done. 

I've left the minute as this is less universal. Some do, some don't. I think I prefer not, but I'm not sure. Perhaps smoothing minutes should be an additional configuration option?

@schorschii 