### PR TITLE
3 applets: set author to none for abandoned desklets

### DIFF
--- a/TimeAndDate@nightflame/info.json
+++ b/TimeAndDate@nightflame/info.json
@@ -1,1 +1,4 @@
-{"author": "nightflame"}
+{
+    "author": "none",
+    "original_author": "nightflame"
+}

--- a/WeatherUnderground@nightflame/info.json
+++ b/WeatherUnderground@nightflame/info.json
@@ -1,1 +1,4 @@
-{"author": "nightflame"}
+{
+    "author": "none",
+    "original_author": "nightflame"
+}

--- a/binaryclockdesklet@entelechy/info.json
+++ b/binaryclockdesklet@entelechy/info.json
@@ -1,1 +1,4 @@
-{"author": "entelechy"}
+{
+    "author": "none",
+    "original_author": "entelechy"
+}


### PR DESCRIPTION
These desklets are abandoned and the authors never responded and have no activity on GitHub in the last few years. So move authors to `original_author` and set author to `none`

@entelechy
@nightflame