### PR TITLE
simple-system-monitor: add some simple imports for gtop, nmclient and…

### DIFF
--- a/simple-system-monitor@ariel/files/simple-system-monitor@ariel/desklet.js
+++ b/simple-system-monitor@ariel/files/simple-system-monitor@ariel/desklet.js
@@ -6,6 +6,9 @@ const GLib = imports.gi.GLib;
 const Cinnamon = imports.gi.Cinnamon;
 const Gettext = imports.gettext;
 const UUID = "simple-system-monitor@ariel";
+const GTop = imports.gi.GTop;
+const NMClient = imports.gi.NMClient;
+const NetworkManager = imports.gi.NetworkManager;
 
 // l10n/translation support
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");


### PR DESCRIPTION
… network manager

In Cinnamon 3.4 the desklet is failing, perhaps the new cjs version,
and the try/catch way of catching missing dependencies and including
the imports is not working.
While this change does not make the dependency messaging work, it does
restore basic functionality for a user that has the required
dependencies installed