### PR TITLE
[analog-clock@cobinja.de] Fix timezone label in Blue light basic theme

### DIFF
--- a/analog-clock@cobinja.de/files/analog-clock@cobinja.de/themes/Blue light basic/metadata.json
+++ b/analog-clock@cobinja.de/files/analog-clock@cobinja.de/themes/Blue light basic/metadata.json
@@ -6,5 +6,5 @@
   "hour": {"fileName": "hour.svg", "pivot-x": 2, "pivot-y": 43.5},
   "minute": {"fileName": "minute.svg", "pivot-x": 1.5, "pivot-y": 53.5},
   "second": {"fileName": "second.svg", "pivot-x": 1.5, "pivot-y": 43.5},
-  "tz-label": "color: #cccccc; font-weight: bold;"
+  "tz-label": "color: #cccccc; font-weight: bold; font-size: 13px;"
 }


### PR DESCRIPTION
The timezone label was not displayed inside the clock.