### PR TITLE
googleCalendar@javahelps.com: add translation support

### DIFF
--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/desklet.js
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/desklet.js
@@ -227,7 +227,7 @@ GoogleCalendarDesklet.prototype = {
 
         this.window.add(this.label);
         this.setContent(this.window);
-        this.label.set_text("Retrieving events...")
+        this.label.set_text(_("Retrieving events..."))
     },
 
     /**
@@ -295,7 +295,7 @@ GoogleCalendarDesklet.prototype = {
                 content = this.formatFileContent(this.file_content, this.date_format, this.use_24h_clock);
             } catch (e) {
                 global.logError(e);
-                content = "Unable to retrieve events..."
+                content = _("Unable to retrieve events...")
             }
             this.label.set_text(content);
         } else {
@@ -324,10 +324,10 @@ GoogleCalendarDesklet.prototype = {
                     this.file_content = commandOutput;
                 } catch (e) {
                     global.logError(e);
-                    content = "Unable to retrieve events..."
+                    content = _("Unable to retrieve events...")
                 }
             } else {
-                content = "No events found..."
+                content = _("No events found...")
             }
 
             this.label.set_text(content);

--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/po/de.po
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/po/de.po
@@ -1,0 +1,164 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-09-17 01:06+0200\n"
+"PO-Revision-Date: 2017-09-17 01:09+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. googleCalendar@javahelps.com->metadata.json->name
+#: desklet.js:171
+msgid "Google Calendar"
+msgstr "Google Kalender"
+
+#: desklet.js:230
+msgid "Retrieving events..."
+msgstr "Termine werden abgerufen …"
+
+#: desklet.js:298 desklet.js:327
+msgid "Unable to retrieve events..."
+msgstr "Termine können nicht abgerufen werden …"
+
+#: desklet.js:330
+msgid "No events found..."
+msgstr "Keine Termine gefunden …"
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->date_format->description
+msgid "Date format"
+msgstr "Datumsformat"
+
+#. googleCalendar@javahelps.com->settings-schema.json->date_format->tooltip
+msgid "Enter the date format here"
+msgstr "Das Datumsformat hier eingeben"
+
+#. googleCalendar@javahelps.com->settings-schema.json->interval->description
+msgid "Number of days to include"
+msgstr "Anzahl der Tage, die einbezogen werden sollen"
+
+#. googleCalendar@javahelps.com->settings-schema.json->interval->tooltip
+msgid "Show the agenda for these number of days"
+msgstr "Die Terminplanung für diese Anzahl an Tagen anzeigen"
+
+#. googleCalendar@javahelps.com->settings-schema.json->interval->units
+msgid "days"
+msgstr "Tage"
+
+#. googleCalendar@javahelps.com->settings-schema.json->top->description
+msgid "Calendar configuration"
+msgstr "Kalenderkonfiguration"
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->calendarName->description
+msgid "Calendar name(s)"
+msgstr "Kalendername(n)"
+
+#. googleCalendar@javahelps.com->settings-schema.json->calendarName->tooltip
+msgid "Enter your calendar names separated by comma here"
+msgstr "Ihre Kalendernamen, getrennt durch Kommata, hier eingeben"
+
+#. googleCalendar@javahelps.com->settings-schema.json->zoom->description
+msgid "Zoom by"
+msgstr "Vergrößern um"
+
+#. googleCalendar@javahelps.com->settings-schema.json->zoom->tooltip
+msgid "Change the size of the desklet"
+msgstr "Die Größe des Desklets ändern"
+
+#. googleCalendar@javahelps.com->settings-schema.json->zoom->units
+msgid "times"
+msgstr "mal"
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->tomorrow_format->description
+msgid "Tomorrow format"
+msgstr "»Morgen«-Format"
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->tomorrow_format->tooltip
+msgid "Enter the tomorrow format here"
+msgstr "Das Format für »Morgen« hier eingeben"
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->today_format->description
+msgid "Today format"
+msgstr "»Heute«-Format"
+
+#. googleCalendar@javahelps.com->settings-schema.json->today_format->tooltip
+msgid "Enter the today format here"
+msgstr "Das Format für »Heute« hier eingeben"
+
+#. googleCalendar@javahelps.com->settings-schema.json->delay->description
+msgid "Update every:"
+msgstr "Aktualisieren alle:"
+
+#. googleCalendar@javahelps.com->settings-schema.json->delay->units
+msgid "minutes"
+msgstr "Minuten"
+
+#. googleCalendar@javahelps.com->settings-schema.json->bgcolor->description
+msgid "Background color"
+msgstr "Hintergrundfarbe"
+
+#. googleCalendar@javahelps.com->settings-schema.json->bgcolor->tooltip
+msgid "Click the button to select a new background color"
+msgstr "Den Knopf klicken, um eine neue Hintergrundfarbe auszuwählen"
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->cornerradius->description
+msgid "Corner radius"
+msgstr "Eckenradius"
+
+#. googleCalendar@javahelps.com->settings-schema.json->cornerradius->tooltip
+msgid "Radius for rounding the desklet's corners"
+msgstr "Radius zum Abrunden der Ecken des Desklets"
+
+#. googleCalendar@javahelps.com->settings-schema.json->cornerradius->units
+msgid "px"
+msgstr "px"
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->transparency->description
+msgid "Transparency"
+msgstr "Transparenz"
+
+#. googleCalendar@javahelps.com->settings-schema.json->transparency->tooltip
+msgid "Set the transparency of the desklet"
+msgstr "Die Transparenz des Desklets einstellen"
+
+#. googleCalendar@javahelps.com->settings-schema.json->textcolor->description
+msgid "Text color"
+msgstr "Textfarbe"
+
+#. googleCalendar@javahelps.com->settings-schema.json->textcolor->tooltip
+msgid "Click the button to select a new text color"
+msgstr "Den Knopf klicken, um eine neue Textfarbe auszuwählen"
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->use_24h_clock->description
+msgid "Use 24h clock"
+msgstr "24-Stunden-Zählung verwenden"
+
+#. googleCalendar@javahelps.com->settings-schema.json->use_24h_clock->tooltip
+msgid "Check to show time in 24h"
+msgstr "Auswählen, um die Zeit in der 24-Stunden-Zählung anzuzeigen"
+
+#. googleCalendar@javahelps.com->settings-schema.json->display->description
+msgid "Desklet style"
+msgstr "Desklet-Stil"
+
+#. googleCalendar@javahelps.com->metadata.json->description
+msgid "A desklet that displays your agenda based on Google Calendar"
+msgstr "Ein Desklet, das Ihre Terminplanung basierend auf Google Kalender anzeigt"

--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/po/googleCalendar.pot
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/po/googleCalendar.pot
@@ -1,0 +1,163 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-09-17 01:06+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: \n"
+
+#. googleCalendar@javahelps.com->metadata.json->name
+#: desklet.js:171
+msgid "Google Calendar"
+msgstr ""
+
+#: desklet.js:230
+msgid "Retrieving events..."
+msgstr ""
+
+#: desklet.js:298 desklet.js:327
+msgid "Unable to retrieve events..."
+msgstr ""
+
+#: desklet.js:330
+msgid "No events found..."
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->date_format->description
+msgid "Date format"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->date_format->tooltip
+msgid "Enter the date format here"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->interval->description
+msgid "Number of days to include"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->interval->tooltip
+msgid "Show the agenda for these number of days"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->interval->units
+msgid "days"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->top->description
+msgid "Calendar configuration"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->calendarName->description
+msgid "Calendar name(s)"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->calendarName->tooltip
+msgid "Enter your calendar names separated by comma here"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->zoom->description
+msgid "Zoom by"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->zoom->tooltip
+msgid "Change the size of the desklet"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->zoom->units
+msgid "times"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->tomorrow_format->description
+msgid "Tomorrow format"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->tomorrow_format->tooltip
+msgid "Enter the tomorrow format here"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->today_format->description
+msgid "Today format"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->today_format->tooltip
+msgid "Enter the today format here"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->delay->description
+msgid "Update every:"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->delay->units
+msgid "minutes"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->bgcolor->description
+msgid "Background color"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->bgcolor->tooltip
+msgid "Click the button to select a new background color"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->cornerradius->description
+msgid "Corner radius"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->cornerradius->tooltip
+msgid "Radius for rounding the desklet's corners"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->cornerradius->units
+msgid "px"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->transparency->description
+msgid "Transparency"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->transparency->tooltip
+msgid "Set the transparency of the desklet"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->textcolor->description
+msgid "Text color"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->textcolor->tooltip
+msgid "Click the button to select a new text color"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-
+#. schema.json->use_24h_clock->description
+msgid "Use 24h clock"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->use_24h_clock->tooltip
+msgid "Check to show time in 24h"
+msgstr ""
+
+#. googleCalendar@javahelps.com->settings-schema.json->display->description
+msgid "Desklet style"
+msgstr ""
+
+#. googleCalendar@javahelps.com->metadata.json->description
+msgid "A desklet that displays your agenda based on Google Calendar"
+msgstr ""


### PR DESCRIPTION
... and German translation

@slgobinath fyi
If Strings in the desklet.js file need to be translated, you need to put them in brackets with an underscore, i.e. like this `_("")`

The translation template file (important for translators) is `po/googleCalendar.pot`. If you add/change translatable strings, you don't need to update the translation files `.po`, but you need only to update the template `.pot` file with the following command:
```
cd ~/.local/share/cinnamon/desklets/googleCalendar@javahelps.com
cinnamon-json-makepot --js po/googleCalendar.pot
```