### PR TITLE
Add support for OpenWeatherMap with a free account

### DIFF
--- a/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/help.html
+++ b/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/help.html
@@ -89,6 +89,11 @@ del {text-decoration: line-through;}
     <p><strong>Open Weather Map requires an API Key</strong>. To obtain an API Key for Open Weather Map
     <a href="http://openweathermap.org/appid">register on the Open Weather 
     Map website</a>.</p>
+    <h3 id="owm2">Open Weather Map Free</h3>
+    <p>Open Weather Map free account only offers 5 days/3 hour forecast API (no daily forecast).</p>
+    <p>Using this service will merge 3 hours forecasts for next 3 days (less accurate but usefull).</p>
+	<p><strong>Open Weather Map Free requires an API Key</strong>. To obtain an API Key for Open Weather
+    Map <a href="http://openweathermap.org/appid">register on the Open Weather Map website</a>.</p>
     <h3 id="yahoo">Yahoo</h3>
     <p class="notice">Unfortunately Yahoo! is no longer supported because of an incompatible change to the Yahoo! API</p>
     <p>Visit <a href="http://weather.yahoo.com/">Yahoo! Weather</a> and search

--- a/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/settings-schema.json
+++ b/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/settings-schema.json
@@ -10,7 +10,8 @@
     "description" : "Data service",
     "options" : {
         "BBC" : "bbc",
-        "Open Weather Map": "owm",
+        "Open Weather Map (requires API key)": "owm",
+        "Open Weather Map Free (requires API key)": "owm2",
         "Wunderground (requires API key)": "wunderground",
         "World Weather Online (requires API key)": "wwo",
         "World Weather Online Premium (requires API key)": "wwo2",


### PR DESCRIPTION
OpenWeatherMap's [API](https://openweathermap.org/api) differs with a free account ([5 day / 3 hour forecast](https://openweathermap.org/forecast5) or [16 day / daily forecast](https://openweathermap.org/forecast16))
This commit allow users to use the 5 day forecast API (the only one available with free accounts).