### PR TITLE
Added fix for clock ignoring timezone changes.

### DIFF
--- a/analog-clock@cobinja.de/files/analog-clock@cobinja.de/3.0/desklet.js
+++ b/analog-clock@cobinja.de/files/analog-clock@cobinja.de/3.0/desklet.js
@@ -448,13 +448,10 @@ CobiAnalogClock.prototype = {
     let minutes = this._displayTime.get_minute() % 60;
     let seconds = this._displayTime.get_second() % 60;
     
-    if (seconds == 0 || this._initialUpdate) {
-      if (minutes % 2 == 0 || this._initialUpdate) {
-        this._clock.hour.actor.set_rotation_angle(Clutter.RotateAxis.Z_AXIS, DEG_PER_HOUR * hours + (minutes * 0.5));
-      }
-      this._clock.minute.actor.set_rotation_angle(Clutter.RotateAxis.Z_AXIS, DEG_PER_SECOND * minutes);
-      this._initialUpdate = false;
-    }
+    this._clock.hour.actor.set_rotation_angle(Clutter.RotateAxis.Z_AXIS, DEG_PER_HOUR * hours + (minutes * 0.5));
+    this._clock.minute.actor.set_rotation_angle(Clutter.RotateAxis.Z_AXIS, DEG_PER_SECOND * minutes);
+    this._initialUpdate = false;
+
     if (this._settings.values["show-seconds"]) {
       this._clock.second.actor.set_rotation_angle(Clutter.RotateAxis.Z_AXIS, DEG_PER_SECOND * seconds);
     }


### PR DESCRIPTION
@Cobinja: This PR is in reference to issue #268.
I wasn't for sure if the code block was needed that I removed. The problem with the issue was that "_initialUpdate" never gets reset so the clock doesn't properly update when a user changes the timezone. If the conditionals that I removed are needed, then two other possible fixes would be:

1) Set "_initialUpdate" to true in the "_onTimezoneChanged" function.
2) Create a variable named "_hasTimezoneChanged", set it to true on "_onTimezoneChanged" function, add that to the conditional statements I removed (lines 451 & 452), and then set it to false once the hours and minute on the clock are update.
