### PR TITLE
Fix gcalcli 4 argument order mismatch

### DIFF
--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/desklet.js
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/desklet.js
@@ -136,15 +136,7 @@ GoogleCalendarDesklet.prototype = {
      */
     getCalendarCommand() {
         let dateTime = new Date();
-        let command = ["gcalcli", "agenda"];
-        command.push(CalendarUtility.formatParameterDate(dateTime));
-        if (this.interval == null) {
-            this.interval = 7; // Default interval is 7 days
-        }
-        dateTime.setDate(dateTime.getDate() + this.interval);
-        command.push(CalendarUtility.formatParameterDate(dateTime));
-        command.push("--nostarted");
-        command.push("--tsv");
+        let command = ["gcalcli"];
         if (this.calendarName != "") {
             let calendars = this.calendarName.split(",");
             for (let name of calendars) {
@@ -155,6 +147,15 @@ GoogleCalendarDesklet.prototype = {
                 }
             }
         }
+        command.push("agenda");
+        command.push(CalendarUtility.formatParameterDate(dateTime));
+        if (this.interval == null) {
+            this.interval = 7; // Default interval is 7 days
+        }
+        dateTime.setDate(dateTime.getDate() + this.interval);
+        command.push(CalendarUtility.formatParameterDate(dateTime));
+        command.push("--nostarted");
+        command.push("--tsv");     
         return command;
     },
 


### PR DESCRIPTION
`gcalcli` v4.0.0a3 (available on LM 19) expects arguments in a strict order which does not allow current desklet to change Calendar names.
This PR fixes the argument order. New arguments order is checked with both v4.0.0a3 and v3.3.2 (available on LM 18)

@jaszhix please check this PR.

Thanks