### PR TITLE
Removed parseInt logic for PID issue fix.

### DIFF
--- a/top@ryannerd/files/top@ryannerd/desklet.js
+++ b/top@ryannerd/files/top@ryannerd/desklet.js
@@ -529,7 +529,7 @@ TopDesklet.prototype =
             let processes = top.process;
             for(let row=0; row < this.cfgMaxPidLines; row++)
             {
-                this.procGrid[row][0].text = parseInt(processes[row].pid).toString();
+                this.procGrid[row][0].text = processes[row].pid;
                 this.procGrid[row][1].text = processes[row].user;
                 this.procGrid[row][2].text = processes[row].pr;
                 this.procGrid[row][3].text = parseInt(processes[row].ni).toString();


### PR DESCRIPTION
@RyanNerd this PR is for issue #316.

I'm not 100% sure if this will fix the issue. All the regex stuff that the desklet is doing checks out ok and also does not have anything to do with the PID process numbers being displayed. I debugged several spots in the code and believe that this is the one location that could/might be responsible for the cutting off of the digits. Give this PR a shot and see if it helps out. If not, just let me know and I'll go back to the drawing board.