### PR TITLE
analog-clock@cobinja.de: Avoid passing context to SignalManager

### DIFF
--- a/analog-clock@cobinja.de/files/analog-clock@cobinja.de/2.8/desklet.js
+++ b/analog-clock@cobinja.de/files/analog-clock@cobinja.de/2.8/desklet.js
@@ -52,7 +52,7 @@ function CobiAnalogClockSettings(instanceId) {
 CobiAnalogClockSettings.prototype = {
   _init: function(instanceId) {
     this._instanceId = instanceId;
-    this._signalManager = new SignalManager.SignalManager(this);
+    this._signalManager = new SignalManager.SignalManager(null);
     this.values = {};
     
     let settingsDirName = GLib.get_user_config_dir();
@@ -75,7 +75,7 @@ CobiAnalogClockSettings.prototype = {
     this._upgradeSettings();
     
     this._monitor = this._settingsFile.monitor(Gio.FileMonitorFlags.NONE, null);
-    this._signalManager.connect(this._monitor, "changed", this._onSettingsChanged);
+    this._signalManager.connect(this._monitor, "changed", Lang.bind(this, this._onSettingsChanged));
   },
   
   _getDefaultSettingsFile: function() {
@@ -164,7 +164,7 @@ CobiAnalogClock.prototype = {
 
   _init: function(metadata, instanceId){
     Desklet.Desklet.prototype._init.call(this, metadata, instanceId);
-    this._signalManager = new SignalManager.SignalManager(this);
+    this._signalManager = new SignalManager.SignalManager(null);
     this._settings = new CobiAnalogClockSettings(instanceId);
     
     this._displayTime = new GLib.DateTime();
@@ -189,18 +189,18 @@ CobiAnalogClock.prototype = {
     
     let currentMillis = new Date().getMilliseconds();
     let timeoutMillis = (1000 - currentMillis) % 1000;
-    
-    this._signalManager.connect(global, "scale-changed", this._onSizeChanged);
-    this._signalManager.connect(this._settings, "size-changed", this._onSizeChanged);
-    this._signalManager.connect(this._settings, "theme-changed", this._onThemeChanged);
-    this._signalManager.connect(this._settings, "hide-decorations-changed", this._onHideDecorationsChanged);
-    this._signalManager.connect(global.settings, "changed::desklet-decorations", this._onHideDecorationsChanged);
-    this._signalManager.connect(this._settings, "show-seconds-changed", this._onShowSecondsChanged);
-    
-    this._signalManager.connect(this._settings, "timezone-use-changed", this._onTimezoneChanged);
-    this._signalManager.connect(this._settings, "timezone-changed", this._onTimezoneChanged);
-    this._signalManager.connect(this._settings, "timezone-display-changed", this._onTimezoneDisplayChanged);
-    
+
+    this._signalManager.connect(global, "scale-changed", Lang.bind(this, this._onSizeChanged));
+    this._signalManager.connect(this._settings, "size-changed", Lang.bind(this, this._onSizeChanged));
+    this._signalManager.connect(this._settings, "theme-changed", Lang.bind(this, this._onThemeChanged));
+    this._signalManager.connect(this._settings, "hide-decorations-changed", Lang.bind(this, this._onHideDecorationsChanged));
+    this._signalManager.connect(global.settings, "changed::desklet-decorations", Lang.bind(this, this._onHideDecorationsChanged));
+    this._signalManager.connect(this._settings, "show-seconds-changed", Lang.bind(this, this._onShowSecondsChanged));
+
+    this._signalManager.connect(this._settings, "timezone-use-changed", Lang.bind(this, this._onTimezoneChanged));
+    this._signalManager.connect(this._settings, "timezone-changed", Lang.bind(this, this._onTimezoneChanged));
+    this._signalManager.connect(this._settings, "timezone-display-changed", Lang.bind(this, this._onTimezoneDisplayChanged));
+
     this._upClient = new UPowerGlib.Client();
     try {
       this._upClient.connect('notify-resume', Lang.bind(this, this._onPowerResume));


### PR DESCRIPTION
Passing context to the SignalManager constructor creates circular references, which makes memory management more complicated for the JS engine.

This is a fix for https://github.com/linuxmint/Cinnamon/pull/7868.

@Cobinja 