### PR TITLE
simple-system-monitor@ariel update to support  Network Manager changes in Cinnamon 4.0

### DIFF
--- a/simple-system-monitor@ariel/files/simple-system-monitor@ariel/4.0/desklet.js
+++ b/simple-system-monitor@ariel/files/simple-system-monitor@ariel/4.0/desklet.js
@@ -7,8 +7,7 @@ const Cinnamon = imports.gi.Cinnamon;
 const Gettext = imports.gettext;
 const UUID = "simple-system-monitor@ariel";
 const GTop = imports.gi.GTop;
-const NMClient = imports.gi.NMClient;
-const NetworkManager = imports.gi.NetworkManager;
+const NM = imports.gi.NM;
 
 // l10n/translation support
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
@@ -20,8 +19,7 @@ function _(str) {
 let missingDependencies = false;
 
 try {
-    const NMClient = imports.gi.NMClient;
-    const NetworkManager = imports.gi.NetworkManager;
+const NM = imports.gi.NM;
 } catch (e) {
     global.logError(e);
     missingDependencies = true;
@@ -35,10 +33,10 @@ try {
 }
 
 const MISSING_DEPENDENCIES = _("Dependencies missing. Please install \n\
-libgtop, Network Manager and gir bindings \n\
-\t    on Ubuntu: gir1.2-gtop-2.0, gir1.2-networkmanager-1.0 \n\
-\t    on Fedora: libgtop2-devel, NetworkManager-glib-devel \n\
-\t    on Arch: libgtop, networkmanager\n\
+libgtop \n\
+\t    on Ubuntu: gir1.2-gtop-2.0 \n\
+\t    on Fedora: libgtop2-devel \n\
+\t    on Arch: libgtop \n\
 and restart Cinnamon.\n");
 
 const CPU = function () {
@@ -117,7 +115,7 @@ const Net = function () {
 Net.prototype = {
 	_init: function() {
         this.connections = [];
-        this.client = NMClient.Client.new();
+        this.client = NM.Client.new(null);
 		this.update_connections();
 
         if (!this.connections.length){
@@ -143,7 +141,7 @@ Net.prototype = {
             }
         }
         catch(e) {
-            global.logError("Please install Network Manager GObject Introspection Bindings");
+            global.logError("Please install Missing Dependencies");
         }
 
         this.totalDownloaded = 0;
@@ -156,13 +154,13 @@ Net.prototype = {
             this.connections = []
             let connection_list = this.client.get_devices();
             for (let j = 0; j < connection_list.length; j++){
-                if (connection_list[j].state == NetworkManager.DeviceState.ACTIVATED){
+                if (connection_list[j].state == NM.DeviceState.ACTIVATED){
                    this.connections.push(connection_list[j].get_ip_iface());
                 }
             }
         }
         catch(e) {
-            global.logError("Please install Network Manager GObject Introspection Bindings");
+            global.logError("Please install Missing Dependencies");
         }
     },
 
@@ -298,7 +296,7 @@ function main(metadata, desklet_id) {
 ## Version 1.0.0
   * Institute changelog - currently only in desklet.js
   * Changes for Cinnamon 4.0 and higher to avoid segfaults when old Network Manager Library is no longer available by using multiversion with folder 4.0
-    * Comment out all references to NetworkManager
+    * Comment out or delete all references to NetworkManager
     * Replace calls to NetworkManager with equivalent calls to NM
     * Change logError messages to not reference NetworkManager  
 */

--- a/simple-system-monitor@ariel/files/simple-system-monitor@ariel/4.0/stylesheet.css
+++ b/simple-system-monitor@ariel/files/simple-system-monitor@ariel/4.0/stylesheet.css
@@ -1,0 +1,18 @@
+.mainContainer {
+	width: 130px;
+	padding: 10px 10px 10px 10px;
+}
+
+.label {
+	display: inline-block;	
+	color: #aaa;
+}
+
+.title {	
+	text-align: right;
+}
+
+.value {
+	text-align: left;
+	padding-left: 5px;
+}

--- a/simple-system-monitor@ariel/files/simple-system-monitor@ariel/metadata.json
+++ b/simple-system-monitor@ariel/files/simple-system-monitor@ariel/metadata.json
@@ -3,5 +3,8 @@
     "prevent-decorations": false,
     "uuid": "simple-system-monitor@ariel",
     "name": "Simple system monitor",
-	"thermal-file": "/sys/devices/virtual/thermal/thermal_zone0/temp"
+	"thermal-file": "/sys/devices/virtual/thermal/thermal_zone0/temp",
+ "cinnamon-version": ["2.8","3.0","3.2","3.4","3.6","3.8","4.0"],
+ "multiversion": true, 
+ "version": "1.0.0"
 }


### PR DESCRIPTION
Updates for Cinnamon 4.0 to avoid segfaults when old Network Manager Library is no longer available by using a multiversion with a folder 4.0 with changes to:
    * Comment out or delete all references to NetworkManager
    * Replace calls to NetworkManager with equivalent calls to NM
    * Change logError messages to remove references to NetworkManager 

This has been tested under a LiveUSB with Mint 19.1 and Cinnamon 4.03

Fixes #279
