### PR TITLE
netusage@30yavash.com - Replace code which fails to identify active device under Cinnamon 4.0

### DIFF
--- a/netusage@30yavash.com/files/netusage@30yavash.com/desklet.js
+++ b/netusage@30yavash.com/files/netusage@30yavash.com/desklet.js
@@ -53,7 +53,7 @@ MyDesklet.prototype = {
         Desklet.Desklet.prototype._init.call(this, metadata);
 
         this.metadata = metadata
-        this.netDevice = this.metadata["netDevice"];
+        this._Device = this.metadata["netDevice"];
 
         // l10n/translation
         UUID = metadata.uuid;
@@ -80,22 +80,35 @@ MyDesklet.prototype = {
         this._updateDevice();
         this._updateGraph();
         this.timeout = Mainloop.timeout_add_seconds(1, Lang.bind(this, this._updateWidget));
+},
 
+    getInterfaces: function () {
+        return this._client.get_devices();
     },
+
+    isInterfaceAvailable: function (name) {
+        let interfaces = this.getInterfaces();
+        if (interfaces != null) {
+           for (let i = 0; i < interfaces.length; i++) {
+                let iname = interfaces[i].get_iface();
+                if (iname == name && interfaces[i].state == CONNECTED_STATE) {
+
+                   return true;
+                 }
+             }
+        }
+        return false;
+    },
+
     _updateDevice: function() {
         try {
-//          global.logError("device: " + this.netDevice);  // Uncomment only for testing
-            let activeConnections = this._client.get_active_connections();
-            for (let i = 0; i < activeConnections.length; i++) {
-                let a = activeConnections[i];
-                if (a['default']) {
-                    let devices = a.get_devices();
-                    for (let j = 0; j < devices.length; j++) {
-                        let d = devices[j];
-                        if (d._delegate) {
-                            this.netDevice = d.get_iface();
-                            break;
-                        }
+             this._device = "null"
+             let interfaces = this.getInterfaces();
+             if (interfaces != null) {
+                 for (let i = 0; i < interfaces.length; i++) {
+                    let iname = interfaces[i].get_iface();
+                    if (this.isInterfaceAvailable(iname)) {
+                        this._device = iname; 
                     }
                 }
             }
@@ -106,8 +119,10 @@ MyDesklet.prototype = {
     },
     _updateGraph: function() {
         try {
-
-            GLib.spawn_command_line_sync('vnstati -s -ne -i ' + this.netDevice + ' -o /tmp/vnstatlmapplet.png');
+           if (this._device != "null") { 
+//                       global.logError("Testing output - detected device: " + this._device);   // Comment out unless testing
+            GLib.spawn_command_line_sync('vnstati -s -ne -i ' + this._device + ' -o /tmp/vnstatlmapplet.png');
+            }
             let l = new Clutter.BinLayout();
             let b = new Clutter.Box();
             let c = new Clutter.Texture({keep_aspect_ratio: true, filter_quality: 2, filename: "/tmp/vnstatlmapplet.png"});
@@ -121,7 +136,7 @@ MyDesklet.prototype = {
             this.missingDependencies = new St.Label({text: _("Please make sure vnstat and vnstati are installed and that the vnstat daemon is running!") 
                                   + "\n" + _("In Linux Mint, you can simply run 'apt install vnstati' and that will take care of everything.") 
                                   + "\n" + _("In other distributions it might depend on the way things are packaged but its likely to be similar.")
-                                  + "\n" + _("The Interface detected was: " + this.netDevice )
+                                  + "\n" + _("The Interface detected was: " + this._device )
 });
             this.warnings.add(this.missingDependencies);
             this.setContent(this.warnings);
@@ -143,5 +158,8 @@ function main(metadata, desklet_id){
   * Changes for Cinnamon 4.0 and higher to avoid segfaults when old Network Manager Library is no longer available by using multiversion with folder 4.0 - Issues #2094 and #2097
   * Remove Try-Catch as no longer required in 4.0 and associated changes.
   * It is believed that all Distributions packaging Cinnamon 4.0 have changed to the new Network Manager Libraries
+## 1.0.2
+  * Significant change to code to identify device as old code failed under Cinnamon 4.0
+    - New code is identical to that used in applets vnstat@linuxmint.com and netusagemonitor@pdcurtis
   * Change "author" to "pdcurtis"
 */

--- a/netusage@30yavash.com/files/netusage@30yavash.com/metadata.json
+++ b/netusage@30yavash.com/files/netusage@30yavash.com/metadata.json
@@ -1,10 +1,10 @@
 {
-    "uuid": "netusage@30yavash.com", 
-    "description": "Network usage monitor using vnstat", 
-    "name": "Network usage monitor", 
-	"netDevice": "wlan0", 
+    "uuid": "netusage@30yavash.com",
+    "description": "Network usage monitor using vnstat",
+    "name": "Network usage monitor",
+	"netDevice": "wlan0",
     "prevent-decorations": false,
     "multiversion": true,
     "cinnamon-version": ["2.2","2.4","2.6","2.8","3.0","3.2","3.4","3.6","3.8","4.0"],
-    "version": "1.0.1"
+    "version": "1.0.2"
 }


### PR DESCRIPTION
Significant change to code to identify device as old code failed under Cinnamon 4.0
     
* New code is identical to that used in applets vnstat@linuxmint.com and 
* Has been in use since Cinnamon 1.8 in netusagemonitor@pdcurtis

Has been tested in netusage@30yavash.com  under:
 *  Mint 19 with Cinnamon 3.8.9
 * Mint 19.1 Beta with Cinnamon 4.03 on a LiveUSB
