### PR TITLE
clockTow@armandobs14: date format in user language

### DIFF
--- a/clockTow@armandobs14/files/clockTow@armandobs14/desklet.js
+++ b/clockTow@armandobs14/files/clockTow@armandobs14/desklet.js
@@ -59,13 +59,13 @@ MyDesklet.prototype = {
     },
 
     _updateDate: function() {
-       let hourFormat = '%H';
-       let minFormat = '%M';
-       let secFormat = '%S';
-       let locale = GLib.getenv('LANG');
+       let hourFormat = "%H";
+       let minFormat = "%M";
+       let secFormat = "%S";
+       let locale = GLib.getenv("LANG");
        if (locale) {
            // convert $LANG from format "en_GB.UTF-8" to "en-GB"
-           locale = GLib.getenv('LANG').replace(/_/g, "-").replace(/\..+/, "");
+           locale = GLib.getenv("LANG").replace(/_/g, "-").replace(/\..+/, "");
        } else {
            // fallback locale
            locale = "en-US";

--- a/clockTow@armandobs14/files/clockTow@armandobs14/desklet.js
+++ b/clockTow@armandobs14/files/clockTow@armandobs14/desklet.js
@@ -58,17 +58,27 @@ MyDesklet.prototype = {
 	Mainloop.source_remove(this.timeout);
     },
 
-    _updateDate: function(){
-       //let dateFormat = this._dateSettings.get_string('date-format');
+    _updateDate: function() {
        let hourFormat = '%H';
        let minFormat = '%M';
        let secFormat = '%S';
-       let dateFormat = '%A,%e %B';
+       let locale = GLib.getenv('LANG');
+       if (locale) {
+           // convert $LANG from format "en_GB.UTF-8" to "en-GB"
+           locale = GLib.getenv('LANG').replace(/_/g, "-").replace(/\..+/, "");
+       } else {
+           // fallback locale
+           locale = "en-US";
+       }
        let displayDate = new Date();
        this._hour.set_text(displayDate.toLocaleFormat(hourFormat));
        this._min.set_text(displayDate.toLocaleFormat(minFormat));
        this._sec.set_text(displayDate.toLocaleFormat(secFormat));
-       this._date.set_text(displayDate.toLocaleFormat(dateFormat));
+       this._date.set_text(displayDate.toLocaleDateString(locale, {
+           day: "numeric",
+           month: "long",
+           weekday: "long"
+        }));
        this.timeout = Mainloop.timeout_add_seconds(1, Lang.bind(this, this._updateDate));
     }
 }

--- a/clockTow@armandobs14/files/clockTow@armandobs14/metadata.json
+++ b/clockTow@armandobs14/files/clockTow@armandobs14/metadata.json
@@ -2,5 +2,6 @@
  "uuid": "clockTow@armandobs14",
  "name": "ClockTow desklet",
  "description": "A fork desklet that displays the time",
- "prevent-decorations": false
+ "prevent-decorations": false,
+  "last-edited": 1553179797
 }


### PR DESCRIPTION
I suggest using the date format and language depending on the user's locale (LANG env variable).

How it will be: 
![date_ar](https://user-images.githubusercontent.com/3100053/54781580-54b28f80-4c25-11e9-8594-ba4e2ec96be3.png)
arabic

![date_en](https://user-images.githubusercontent.com/3100053/54781589-5a0fda00-4c25-11e9-9e06-d9ec3749fdec.png)
english (us)

![date_ja](https://user-images.githubusercontent.com/3100053/54781597-5e3bf780-4c25-11e9-9e95-48ec0d4e674a.png)
japanese

etc.

