### PR TITLE
[googleCalendar@javahelps.com] Updated xdate.js: avoid error messages in ~/.xsession-errors

### DIFF
--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/lib/xdate.js
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/lib/xdate.js
@@ -24,7 +24,7 @@ var XDate = function(t, e, n, r) {
 
     function i(e, n) {
         var r, i = n.length;
-        if (J(n[i - 1]) && (r = n[--i], n = O(n, 0, i)), i)
+        if (i > 0 && J(n[i - 1]) && (r = n[--i], n = O(n, 0, i)), i)
             if (1 == i) {
                 var o = n[0];
                 o instanceof t ? e[0] = new t(o.getTime()) : G(o) ? e[0] = new t(o) : o instanceof u ? e[0] = D(o) : A(o) && (e[0] = new t(0), e = T(o, r || !1, e))
@@ -98,7 +98,7 @@ var XDate = function(t, e, n, r) {
 
     function T(e, n, r) {
         for (var i, o = u.parsers, s = 0; s < o.length; s++)
-            if (i = o[s](e, n, r)) return i;
+            if (i == o[s](e, n, r)) return i;
         return r[0] = new t(e), r
     }
 


### PR DESCRIPTION
Hi @slgobinath,

I propose two minor changes in `lib/xdate.js` to avoid noisy messages in `~/.xsession-errors`.

Tested for a few days, your fabulous desklet still works very well with these changes.

Kind regards.
Claudiux