### PR TITLE
clock@schorschii: hide seconds hand by default

### DIFF
--- a/clock@schorschii/files/clock@schorschii/settings-schema.json
+++ b/clock@schorschii/files/clock@schorschii/settings-schema.json
@@ -25,7 +25,7 @@
         "type": "checkbox",
         "description": "Show seconds hand",
         "tooltip": "Show or hide the seconds hand.",
-        "default": true
+        "default": false
     },
     "smooth-seconds-hand": {
         "type": "checkbox",


### PR DESCRIPTION
It turned out that the smooth seconds hand feature is CPU intensive, especially on less powerful CPUs. That's why it should be turned off by default.