### PR TITLE
Yahoo Finance Quotes: Fixes missing click support for most details

### DIFF
--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -134,17 +134,20 @@ QuotesTable.prototype = {
     existsProperty : function(object, property) {
       return object.hasOwnProperty(property) && object[property] !== undefined && object[property] !== null;
     },
+    addLinkIfWanted(symbol, element, addLink) {
+        if (addLink) {
+            return this.createLink(element, symbol);
+        } else {
+            return element;
+        }
+    },
     createQuoteSymbolLabel(quote, addLink) {
         const nameLabel =  new St.Label({
             text : quote.symbol,
             style_class : "quotes-label",
             reactive : addLink ? true : false
         });
-        if (addLink) {
-            return this.createLink(nameLabel, quote.symbol);
-        } else {
-            return nameLabel;
-        }
+        return this.addLinkIfWanted(quote.symbol, nameLabel, addLink);
     },
     createMarketPriceLabel(quote, withCurrencySymbol, decimalPlaces, addLink) {
         let currencySymbol = "";
@@ -156,11 +159,7 @@ QuotesTable.prototype = {
             style_class : "quotes-label",
             reactive : addLink ? true : false
         });
-        if (addLink) {
-	    return this.createLink(nameLabel, quote.symbol);
-        } else {
-            return nameLabel;
-        }
+        return this.addLinkIfWanted(quote.symbol, nameLabel, addLink);
     },
     createLink(label, symbol, addLink) {
             const button = new St.Button();
@@ -176,11 +175,7 @@ QuotesTable.prototype = {
             style_class : "quotes-label",
             reactive : addLink ? true : false
         });
-        if (addLink) {
-	    return this.createLink(nameLabel, quote.symbol);
-        } else {
-            return nameLabel;
-        }
+        return this.addLinkIfWanted(quote.symbol, nameLabel, addLink);
     },
     createAbsoluteChangeLabel(quote, withCurrencySymbol, decimalPlaces, addLink) {
         var absoluteChangeText = "";
@@ -198,11 +193,7 @@ QuotesTable.prototype = {
             style_class : "quotes-label",
             reactive : addLink ? true : false
         });
-        if (addLink) {
-	    return this.createLink(nameLabel, quote.symbol);
-        } else {
-            return nameLabel;
-        }
+        return this.addLinkIfWanted(quote.symbol, nameLabel, addLink);
     },
     createPercentChangeIcon(quote, addLink) {
         const percentChange = this.existsProperty(quote, "regularMarketChangePercent") ? parseFloat(quote.regularMarketChangePercent) : 0.0;
@@ -227,11 +218,7 @@ QuotesTable.prototype = {
             reactive : addLink ? true : false
         });
         binIcon.set_child(image);
-        if (addLink) {
-	    return this.createLink(binIcon, quote.symbol);
-        } else {
-            return binIcon;
-        }
+        return this.addLinkIfWanted(quote.symbol, binIcon, addLink);
     },
     createPercentChangeLabel(quote, addLink) {
         const nameLabel =  new St.Label({
@@ -239,11 +226,7 @@ QuotesTable.prototype = {
             style_class : "quotes-label",
             reactive : addLink ? true : false
         });
-        if (addLink) {
-	    return this.createLink(nameLabel, quote.symbol);
-        } else {
-            return nameLabel;
-        }
+        return this.addLinkIfWanted(quote.symbol, nameLabel, addLink);
     },
     roundAmount : function (amount, maxDecimals) {
         if (maxDecimals > -1)  {
@@ -277,17 +260,13 @@ QuotesTable.prototype = {
 
         return tsFormat;
     },
-    createTradeTimeLabel(quote) {
+    createTradeTimeLabel(quote, addLink) {
         const nameLabel =  new St.Label({
             text : this.existsProperty(quote, "regularMarketTime") ? this.formatTime(quote.regularMarketTime) : ABSENT,
             style_class : "quotes-label",
             reactive : addLink ? true : false
         });
-        if (addLink) {
-	    return this.createLink(nameLabel, quote.symbol);
-        } else {
-            return nameLabel;
-        }
+        return this.addLinkIfWanted(quote.symbol, nameLabel, addLink);
     }
 };
 

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -134,19 +134,19 @@ QuotesTable.prototype = {
     existsProperty : function(object, property) {
       return object.hasOwnProperty(property) && object[property] !== undefined && object[property] !== null;
     },
-    createQuoteSymbolLabel : function (quote, addLink) {
+    createQuoteSymbolLabel(quote, addLink) {
         const nameLabel =  new St.Label({
             text : quote.symbol,
             style_class : "quotes-label",
             reactive : addLink ? true : false
         });
         if (addLink) {
-	    return this.createLink(nameLabel, quote.symbol);
+            return this.createLink(nameLabel, quote.symbol);
         } else {
             return nameLabel;
         }
     },
-    createMarketPriceLabel : function (quote, withCurrencySymbol, decimalPlaces, addLink) {
+    createMarketPriceLabel(quote, withCurrencySymbol, decimalPlaces, addLink) {
         let currencySymbol = "";
         if (withCurrencySymbol && this.existsProperty(quote, "currency")) {
             currencySymbol = this.currencyCodeToSymbolMap[quote.currency] || quote.currency;
@@ -162,15 +162,15 @@ QuotesTable.prototype = {
             return nameLabel;
         }
     },
-    createLink : function (label, symbol, addLink) {
+    createLink(label, symbol, addLink) {
             const button = new St.Button();
             button.add_actor(label);
             button.connect("clicked", Lang.bind(this, function() {
                 Gio.app_info_launch_default_for_uri("https://finance.yahoo.com/quote/" + symbol, global.create_app_launch_context());
             }));
-	    return button;
+            return button;
     },
-    createQuoteNameLabel : function (quote, addLink) {
+    createQuoteNameLabel(quote, addLink) {
         const nameLabel =  new St.Label({
             text : this.existsProperty(quote, "shortName") ? quote.shortName : ABSENT,
             style_class : "quotes-label",
@@ -182,7 +182,7 @@ QuotesTable.prototype = {
             return nameLabel;
         }
     },
-    createAbsoluteChangeLabel : function (quote, withCurrencySymbol, decimalPlaces, addLink) {
+    createAbsoluteChangeLabel(quote, withCurrencySymbol, decimalPlaces, addLink) {
         var absoluteChangeText = "";
         if (this.existsProperty(quote, "regularMarketChange")) {
             let absoluteChange = this.roundAmount(quote.regularMarketChange, decimalPlaces);
@@ -204,7 +204,7 @@ QuotesTable.prototype = {
             return nameLabel;
         }
     },
-    createPercentChangeIcon : function (quote, addLink) {
+    createPercentChangeIcon(quote, addLink) {
         const percentChange = this.existsProperty(quote, "regularMarketChangePercent") ? parseFloat(quote.regularMarketChangePercent) : 0.0;
         let path = "";
 
@@ -233,7 +233,7 @@ QuotesTable.prototype = {
             return binIcon;
         }
     },
-    createPercentChangeLabel : function (quote, addLink) {
+    createPercentChangeLabel(quote, addLink) {
         const nameLabel =  new St.Label({
             text : this.existsProperty(quote, "regularMarketChangePercent") ? (this.roundAmount(quote.regularMarketChangePercent, 2) + "%") : ABSENT,
             style_class : "quotes-label",
@@ -277,7 +277,7 @@ QuotesTable.prototype = {
 
         return tsFormat;
     },
-    createTradeTimeLabel : function (quote) {
+    createTradeTimeLabel(quote) {
         const nameLabel =  new St.Label({
             text : this.existsProperty(quote, "regularMarketTime") ? this.formatTime(quote.regularMarketTime) : ABSENT,
             style_class : "quotes-label",

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -149,11 +149,15 @@ QuotesTable.prototype = {
         });
         return this.addLinkIfWanted(quote.symbol, nameLabel, addLink);
     },
-    createMarketPriceLabel(quote, withCurrencySymbol, decimalPlaces, addLink) {
-        let currencySymbol = "";
+    createCurrencySymbolIfWanted(withCurrencySymbol, quote) {
         if (withCurrencySymbol && this.existsProperty(quote, "currency")) {
-            currencySymbol = this.currencyCodeToSymbolMap[quote.currency] || quote.currency;
+            return this.currencyCodeToSymbolMap[quote.currency] || quote.currency;
+        } else {
+            return "";
         }
+    },
+    createMarketPriceLabel(quote, withCurrencySymbol, decimalPlaces, addLink) {
+        const currencySymbol = this.createCurrencySymbolIfWanted(withCurrencySymbol, quote);
         const nameLabel =  new St.Label({
             text : currencySymbol + (this.existsProperty(quote, "regularMarketPrice") ? this.roundAmount(quote.regularMarketPrice, decimalPlaces) : ABSENT),
             style_class : "quotes-label",
@@ -195,19 +199,18 @@ QuotesTable.prototype = {
         });
         return this.addLinkIfWanted(quote.symbol, nameLabel, addLink);
     },
-    createPercentChangeIcon(quote, addLink) {
+    findIcon(quote) {
         const percentChange = this.existsProperty(quote, "regularMarketChangePercent") ? parseFloat(quote.regularMarketChangePercent) : 0.0;
-        let path = "";
-
         if (percentChange > 0) {
-            path = "/icons/up.svg";
+            return "up.svg";
         } else if (percentChange < 0) {
-            path = "/icons/down.svg";
-        } else if (percentChange === 0.0) {
-            path = "/icons/eq.svg";
+            return "down.svg";
+        } else {
+            return "/eq.svg";
         }
-
-        const iconFile = Gio.file_new_for_path(DESKLET_DIR + path);
+    },
+    createPercentChangeIcon(quote, addLink) {
+        const iconFile = Gio.file_new_for_path(DESKLET_DIR + "/icons/" + this.findIcon(quote));
         const uri = iconFile.get_uri();
         const image = St.TextureCache.get_default().load_uri_async(uri, -1, -1);
         image.set_size(20, 20);


### PR DESCRIPTION
The yahoo finance quote of @thegli supports "click-and-surf" to yahoo finance.

But only when the user enabled "Show verbose name" was it possible to use this feature.
This PR makes it possible for all quote details, so that no matter what the user enables/disables, it will always work.