### PR TITLE
Use longname if available

### DIFF
--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -150,9 +150,18 @@ QuotesTable.prototype = {
             style_class : "quotes-label"
         });
     },
+    searchName : function (quote) {
+        if(this.existsProperty(quote, "longName")) {
+            return quote.longName;
+        } else if(this.existsProperty(quote, "shortName")) {
+            return quote.shortName;
+        } else {
+            return ABSENT;
+        }
+    },
     createQuoteNameLabel : function (quote, addLink) {
         const nameLabel =  new St.Label({
-            text : this.existsProperty(quote, "shortName") ? quote.shortName : ABSENT,
+            text : this.searchName(quote),
             style_class : "quotes-label",
             reactive : addLink ? true : false
         });


### PR DESCRIPTION
@thegli

This commit makes it use the long name instead of the short name of the quotes.

Reason:
- This doesn't change anything for well known US stocks (both the short and the long name are the same)
- Before this commit most European stocks received "ugly" short names (e.g. BFIT.AS became "BASIC-FIT".)

This commit "prettifies" those names (for BFIT.AS it would become  "Basic-Fit N.V.").
This way they don't stand and out among the other names.