### PR TITLE
Proposals for cpuload@kimse

### DIFF
--- a/cpuload@kimse/files/cpuload@kimse/desklet.js
+++ b/cpuload@kimse/files/cpuload@kimse/desklet.js
@@ -284,7 +284,7 @@ CpuLoadDesklet.prototype = {
         canvas.set_size(this.cpu_container_size, this.cpu_container_size);
         canvas.connect('draw', function(canvas, cr, width, height) {
 
-            let offset = Math.PI * (desklet.circle == 'speedometer' ? 1.25 : 0.5);
+            let offset = Math.PI * (desklet.circle == 'speedometer' ? 1.25 : 1.5);
             let start = 0 - offset;
             let end = ((cpu_active_time * (Math.PI * (desklet.circle == 'speedometer' ? 1.5 : 2) )) / 100) - offset;
 

--- a/cpuload@kimse/files/cpuload@kimse/desklet.js
+++ b/cpuload@kimse/files/cpuload@kimse/desklet.js
@@ -23,10 +23,10 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Initializes the desklet.
-     * 
-     * @param {Object}  metadata 
-     * @param {string}  deskletId 
-     * 
+     *
+     * @param {Object}  metadata
+     * @param {string}  deskletId
+     *
      * @returns {Object}
      */
     _init(metadata, deskletId) {
@@ -39,6 +39,7 @@ CpuLoadDesklet.prototype = {
         this.settings.bindProperty(Settings.BindingDirection.IN, 'number-of-columns', 'number_of_columns', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'refresh-interval', 'refresh_interval', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'design', 'design', this.on_setting_changed);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'circle', 'circle', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'color-theme', 'color_theme', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'static-theme-color', 'static_theme_color', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'show-background', 'show_background', this.on_setting_changed);
@@ -49,9 +50,9 @@ CpuLoadDesklet.prototype = {
         this.cpus_active_time = [];
         this.cpus_total_time = [];
         this.colors = [];
-        this.cpu_container_outer_base_width = 170;
-        this.cpu_container_inner_base_width = 150;
-        this.large_font_size = 20;
+        this.cpu_container_outer_base_width = 175;
+        this.cpu_container_inner_base_width = 160;
+        this.large_font_size = 22;
         this.normal_font_size = 13;
         this.has_previous_sample = false;
 
@@ -103,7 +104,7 @@ CpuLoadDesklet.prototype = {
      * Main desklet loop.
      */
     main() {
-        
+
         // Refresh CPU activity
         this.refreshCpuActivity(this.drawCpuActivity);
 
@@ -112,11 +113,11 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Refresh CPU activity.
-     * 
-     * @param {Object=} callback 
+     *
+     * @param {Object=} callback
      */
     refreshCpuActivity(callback = null) {
-        
+
         let desklet = this;
 
         // Get cpu activity sample
@@ -147,13 +148,13 @@ CpuLoadDesklet.prototype = {
 
             // Create CPU meter
             let container = this.makeCpuContainer(
-                    this.makeCpuCoreCanvas(core), 
+                    this.makeCpuCoreCanvas(core),
                     pos_x,
                     pos_y
                 );
 
             // Create CPU core label
-            let cpu_load = this.makeCpuLoadLabel(core, pos_x, pos_y);           
+            let cpu_load = this.makeCpuLoadLabel(core, pos_x, pos_y);
             let cpu_name = this.makeCpuNameLabel(core, pos_x, pos_y);
 
             // Calculate position of the next CPU meter
@@ -173,11 +174,11 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Refresh CPU activity.
-     * 
+     *
      * @param {Clutter.Canvas}  canvas
      * @param {number}          pos_x
      * @param {number}          pos_y
-     * 
+     *
      * @returns {Clutter.Actor}
      */
     makeCpuContainer(canvas, pos_x, pos_y){
@@ -193,16 +194,16 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Make a CPU load label.
-     * 
+     *
      * @param {number}  cpu_active_time
      * @param {number}  pos_x
      * @param {number}  pos_y
-     * 
+     *
      * @returns {St.Label}
      */
     makeCpuLoadLabel(core, pos_x, pos_y){
 
-        let label = new St.Label();
+        let label = new St.Label({style_class:"cpuLoad"});
         let cpu_active_time = this.cpus_utilization[core];
 
         label.set_position(pos_x, pos_y + (this.cpu_container_size / 2) - (this.cpu_load_font_size * (1.35 * global.ui_scale)));
@@ -215,17 +216,17 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Make a CPU name label.
-     * 
+     *
      * @param {number}  core
      * @param {number}  pos_x
      * @param {number}  pos_y
-     * 
+     *
      * @returns {St.Label}
      */
     makeCpuNameLabel(core, pos_x, pos_y)
     {
-        let label = new St.Label();
-        
+        let label = new St.Label({style_class:"cpuName"});
+
         label.set_position(pos_x, pos_y + (this.cpu_container_size / 2) + (this.cpu_name_font_size / global.ui_scale) / 4);
         label.set_text(this.per_core ? _("Core %d").format(core) : _("CPU usage"));
 
@@ -236,22 +237,21 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Get text label style.
-     * 
+     *
      * @param {number}  font_size
-     * 
+     *
      * @returns {string}
      */
     getTextLabelStyle(font_size){
-        return "text-align:center;font-size: " + font_size + "px;" + 
-               "font-family: 'Sawasdee', sans-serif;" + 
+        return "font-size: " + font_size + "px;" +
                "width:" + (this.cpu_container_size / global.ui_scale) + "px";
     },
-    
+
     /**
      * Check if a previous CPU activity data sample has been collected.
-     * 
+     *
      * @param {number}  num_cpus
-     * 
+     *
      * @returns {boolean}
      */
     hasPreviousSample(num_cpus){
@@ -269,9 +269,9 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Make CPU meter canvas.
-     * 
+     *
      * @param {number}  core
-     * 
+     *
      * @returns {Clutter.Canvas}
      */
     makeCpuCoreCanvas(core) {
@@ -284,15 +284,17 @@ CpuLoadDesklet.prototype = {
         canvas.set_size(this.cpu_container_size, this.cpu_container_size);
         canvas.connect('draw', function(canvas, cr, width, height) {
 
-            let offset = Math.PI * 0.5;
+            let offset = Math.PI * (desklet.circle == 'speedometer' ? 1.25 : 0.5);
             let start = 0 - offset;
-            let end = ((cpu_active_time * (Math.PI * 2)) / 100) - offset;
+            let end = ((cpu_active_time * (Math.PI * (desklet.circle == 'speedometer' ? 1.5 : 2) )) / 100) - offset;
 
             desklet.drawCircleShape(cr, width, height);
 
             if(desklet.design === 'thin') {
                 desklet.drawThinCircleShape(cr, start, end, color);
-            } else {                
+            } else if(desklet.design === 'compact') {
+                desklet.drawCompactCircleShape(cr, start, end, color);
+            } else {
                 desklet.drawThickCircleShape(cr, start, end, color);
             }
         });
@@ -303,7 +305,7 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Draw CPU meter shape model.
-     * 
+     *
      * @param {Cario}   cr
      * @param {number}  width
      * @param {number}  height
@@ -320,7 +322,7 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Draw thin CPU meter design.
-     * 
+     *
      * @param {Cario}   cr
      * @param {number}  start
      * @param {number}  end
@@ -328,34 +330,43 @@ CpuLoadDesklet.prototype = {
      */
     drawThinCircleShape(cr, start, end, color){
 
+        cr.setLineCap(Cairo.LineCap.ROUND);
+
         if(this.show_background) {
             cr.setSourceRGBA(1, 1, 1, 0.2);
-            cr.setLineWidth(0.04);
-            cr.arc(0, 0, 0.4, 0, Math.PI * 2);
+            cr.setLineWidth(0.045);
+            if(this.circle == 'speedometer') {
+                cr.arc(0, 0, 0.45, 0-(Math.PI*1.25), Math.PI*0.25);
+            } else {
+                cr.arc(0, 0, 0.45, 0, Math.PI*2);
+            }
             cr.stroke();
         }
 
-        cr.setLineCap(Cairo.LineCap.ROUND);
         cr.setSourceRGBA(color.r, color.g, color.b, color.a);
-        cr.setLineWidth(0.04);
-        cr.arc(0, 0, 0.4, start, end);
+        cr.setLineWidth(0.045);
+        cr.arc(0, 0, 0.45, start, end);
         cr.stroke();
     },
 
     /**
      * Draw thick CPU meter design.
-     * 
+     *
      * @param {Cario}   cr
      * @param {number}  start
      * @param {number}  end
      * @param {Object}  color
      */
     drawThickCircleShape(cr, start, end, color){
-        
+
         if(this.show_background) {
             cr.setSourceRGBA(1, 1, 1, 0.2);
             cr.setLineWidth(0.20);
-            cr.arc(0, 0, 0.4, 0, Math.PI * 2);
+            if(this.circle == 'speedometer') {
+                cr.arc(0, 0, 0.4, 0-(Math.PI*1.25), Math.PI*0.25);
+            } else {
+                cr.arc(0, 0, 0.4, 0, Math.PI*2);
+            }
             cr.stroke();
         }
 
@@ -368,12 +379,39 @@ CpuLoadDesklet.prototype = {
         cr.arc(0, 0, 0.325, start, end);
         cr.stroke();
     },
-    
+
+    /**
+     * Draw compact CPU meter design.
+     *
+     * @param {Cario}   cr
+     * @param {number}  start
+     * @param {number}  end
+     * @param {Object}  color
+     */
+    drawCompactCircleShape(cr, start, end, color){
+
+        if(this.show_background) {
+            cr.setSourceRGBA(1, 1, 1, 0.2);
+            cr.setLineWidth(0.4);
+            if(this.circle == 'speedometer') {
+                cr.arc(0, 0, 0.2, 0-(Math.PI*1.25), Math.PI*0.25);
+            } else {
+                cr.arc(0, 0, 0.2, 0, Math.PI*2);
+            }
+            cr.stroke();
+        }
+
+        cr.setSourceRGBA(color.r, color.g, color.b, color.a);
+        cr.setLineWidth(0.4);
+        cr.arc(0, 0, 0.2, start, end);
+        cr.stroke();
+    },
+
     /**
      * Get CPU meter color based on user-defined color theme.
-     * 
+     *
      * @param {number}  core
-     * 
+     *
      * @return {Object}
      */
     getCpuColor(core) {
@@ -404,9 +442,9 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Get a dynamic RGB color based on the given CPU core utilization.
-     * 
-     * @param {number} core 
-     * 
+     *
+     * @param {number} core
+     *
      * @returns {Object}
      */
     getDynamicRgbColor(core) {
@@ -422,7 +460,7 @@ CpuLoadDesklet.prototype = {
             b: 10.0/255,
             a: 1
         };
-        
+
         return {
             r: green.r + (this.cpus_utilization[core] / 100) * (red.r - green.r),
             g: green.g + (this.cpus_utilization[core] / 100) * (red.g - green.g),
@@ -433,9 +471,9 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Get the static user defined RGB color.
-     * 
+     *
      * @param {number} core
-     * 
+     *
      * @returns {Object}
      */
     getStaticRgbColor() {
@@ -454,7 +492,7 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Make a random color
-     * 
+     *
      * @returns {Object}
      */
     makeRandomRgbColor() {
@@ -471,10 +509,10 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Get CPU activity sample
-     * 
+     *
      * @async
      * @param {boolean}  per_core
-     * 
+     *
      * @returns {Object}
      */
     async getCpuActivitySample(per_core) {
@@ -490,7 +528,7 @@ CpuLoadDesklet.prototype = {
             } else {
                 activity = proc_stat.match(/^cpu\ +.+$/mg);
             }
-                
+
             return activity;
 
         } catch (e) {
@@ -500,9 +538,9 @@ CpuLoadDesklet.prototype = {
 
     /**
      * Read /proc/stat file
-     * 
+     *
      * @param {Cancellable=}  cancellable
-     * 
+     *
      * @returns {Promise}
      */
     readProcStatFileAsync(cancellable = null) {
@@ -510,10 +548,10 @@ CpuLoadDesklet.prototype = {
         let file = Gio.File.new_for_path('/proc/stat');
 
         return new Promise((resolve, reject) => {
-            file.load_contents_async(cancellable, (source_object, result) => {                
+            file.load_contents_async(cancellable, (source_object, result) => {
                 try {
                     result = source_object.load_contents_finish(result);
-                    
+
                     let [success, proc_stat] = result;
 
                     resolve(proc_stat);
@@ -525,9 +563,9 @@ CpuLoadDesklet.prototype = {
     },
 
     /**
-     * Parses /proc/stat content 
-     * 
-     * @param {string} activity 
+     * Parses /proc/stat content
+     *
+     * @param {string} activity
      */
     updateCpuActivity(activity) {
 
@@ -544,7 +582,7 @@ CpuLoadDesklet.prototype = {
                             parseInt(load[3]) +          // system: Time spent in system mode.
                             parseInt(load[7]) +          // softirq: Time servicing softirqs.
                             parseInt(load[8]);           // stolen: Stolen time, which is the time spent in other operating systems when running in a virtualized environment
-                   
+
             cpus_total_time[core] = parseInt(load[1]) +  // user: Time spent in user mode.
                             parseInt(load[2]) +          // nice: Time spent in user mode with low priority (nice).
                             parseInt(load[3]) +          // system: Time spent in system mode.
@@ -552,7 +590,7 @@ CpuLoadDesklet.prototype = {
                             parseInt(load[5]) +          // iowait: Time waiting for I/O to complete
                             parseInt(load[7]) +          // softirq: Time servicing softirqs.
                             parseInt(load[8]);           // stolen: Stolen time, which is the time spent in other operating systems when running in a virtualized environment
-  
+
             if(this.hasPreviousSample(activity.length)){
                 this.cpus_utilization[core] = Math.round(
                     (100 * (cpus_active_time[core] - this.cpus_active_time[core]) / (cpus_total_time[core] - this.cpus_total_time[core]))
@@ -599,10 +637,10 @@ CpuLoadDesklet.prototype = {
 
 /**
  * CPU Load desklet class
- * 
+ *
  * @class
- * @param {Object} metadata 
- * @param {string} deskletId 
+ * @param {Object} metadata
+ * @param {string} deskletId
  */
 function CpuLoadDesklet(metadata, deskletId) {
     this._init(metadata, deskletId);

--- a/cpuload@kimse/files/cpuload@kimse/metadata.json
+++ b/cpuload@kimse/files/cpuload@kimse/metadata.json
@@ -2,6 +2,6 @@
     "max-instances": "1",
     "description": "Displays CPU load",
     "name": "CPU Load",
-    "version": "0.5",
+    "version": "0.6",
     "uuid": "cpuload@kimse"
 }

--- a/cpuload@kimse/files/cpuload@kimse/po/cpuload@kimse.pot
+++ b/cpuload@kimse/files/cpuload@kimse/po/cpuload@kimse.pot
@@ -79,6 +79,22 @@ msgstr ""
 msgid "Thin"
 msgstr ""
 
+#. settings-schema.json->design->options
+msgid "Compact"
+msgstr ""
+
+#. settings-schema.json->circle->description
+msgid "Circle"
+msgstr ""
+
+#. settings-schema.json->circle->options
+msgid "Speedometer"
+msgstr ""
+
+#. settings-schema.json->circle->options
+msgid "Full Circle"
+msgstr ""
+
 #. settings-schema.json->scale-size->units
 msgid "scale factor"
 msgstr ""

--- a/cpuload@kimse/files/cpuload@kimse/po/de.po
+++ b/cpuload@kimse/files/cpuload@kimse/po/de.po
@@ -77,6 +77,22 @@ msgstr "Dick"
 msgid "Thin"
 msgstr "Dünn"
 
+#. settings-schema.json->design->options
+msgid "Compact"
+msgstr "Kompakt"
+
+#. settings-schema.json->circle->description
+msgid "Circle"
+msgstr "Kreis"
+
+#. settings-schema.json->circle->options
+msgid "Speedometer"
+msgstr "Tachometer"
+
+#. settings-schema.json->circle->options
+msgid "Full Circle"
+msgstr "Voller Kreis"
+
 #. settings-schema.json->scale-size->units
 msgid "scale factor"
 msgstr "Skalierungsfaktor"

--- a/cpuload@kimse/files/cpuload@kimse/settings-schema.json
+++ b/cpuload@kimse/files/cpuload@kimse/settings-schema.json
@@ -32,8 +32,18 @@
         "default": "thick",
         "description": "Design",
         "options" : {
-            "Thick" : "thick",
-            "Thin": "thin"
+            "Thin": "thin",
+            "Compact": "compact",
+            "Thick" : "thick"
+        }
+    },
+    "circle": {
+        "type": "combobox",
+        "default": "speedometer",
+        "description": "Circle",
+        "options" : {
+            "Speedometer": "speedometer",
+            "Full Circle": "full-circle"
         }
     },
     "scale-size": {

--- a/cpuload@kimse/files/cpuload@kimse/stylesheet.css
+++ b/cpuload@kimse/files/cpuload@kimse/stylesheet.css
@@ -1,0 +1,6 @@
+/* labels */
+.cpuLoad, .cpuName {
+	font-family: "Ubuntu", sans-serif;
+	font-weight: 200;
+	text-align: center;
+}


### PR DESCRIPTION
Hi @ipimpat 

I'm using the cpuload and diskspace desklet, which gave me the following ideas to improve the UX for people using both. Hope you like it.

- I propose to change the circle to a "speedometer-like" design. The speedometer design is more common for CPU usage visualization and users can differentiate it from the diskspace desklet on the first sight.
- I propose to adjust the default size to match the default diskspace desklet size.
- I added the new compact design known from the diskspace desklet.

![Bildschirmfoto vom 2020-10-01 15-52-56](https://user-images.githubusercontent.com/17480795/95759816-8200db80-0caa-11eb-9fd4-8363393afd7a.png)
![Bildschirmfoto vom 2020-10-01 15-56-33](https://user-images.githubusercontent.com/17480795/95759819-82997200-0caa-11eb-9a31-ba3c506bb2b5.png)
