### PR TITLE
diskspace@schorschii: option to choose decimal/binary prefix

### DIFF
--- a/diskspace@schorschii/files/diskspace@schorschii/metadata.json
+++ b/diskspace@schorschii/files/diskspace@schorschii/metadata.json
@@ -2,6 +2,6 @@
     "max-instances": "10",
     "description": "Displays the usage of a filesystem or RAM.",
     "name": "Disk Space",
-    "version": "1.11",
+    "version": "1.12",
     "uuid": "diskspace@schorschii"
 }

--- a/diskspace@schorschii/files/diskspace@schorschii/po/de.po
+++ b/diskspace@schorschii/files/diskspace@schorschii/po/de.po
@@ -86,6 +86,15 @@ msgstr "Freier Speicherplatz und Kapazität"
 msgid "No text"
 msgstr "Kein Text"
 
+msgid "Size Prefix"
+msgstr "Präfixe"
+
+msgid "Decimal"
+msgstr "Dezimal"
+
+msgid "Binary"
+msgstr "Binär"
+
 msgid "Hide decorations"
 msgstr "Dekorationen verstecken"
 

--- a/diskspace@schorschii/files/diskspace@schorschii/po/diskspace@schorschii.pot
+++ b/diskspace@schorschii/files/diskspace@schorschii/po/diskspace@schorschii.pot
@@ -84,6 +84,15 @@ msgstr ""
 msgid "No text"
 msgstr ""
 
+msgid "Size Prefix"
+msgstr ""
+
+msgid "Decimal"
+msgstr ""
+
+msgid "Binary"
+msgstr ""
+
 msgid "Hide decorations"
 msgstr ""
 

--- a/diskspace@schorschii/files/diskspace@schorschii/settings-schema.json
+++ b/diskspace@schorschii/files/diskspace@schorschii/settings-schema.json
@@ -64,6 +64,15 @@
             "No text": "none"
         }
     },
+    "size-prefix": {
+        "type": "combobox",
+        "default": "binary",
+        "description": "Size Prefix",
+        "options" : {
+            "Decimal" : "decimal",
+            "Binary": "binary"
+        }
+    },
     "hide-decorations": {
         "type": "checkbox",
         "description": "Hide decorations",


### PR DESCRIPTION
This PR adds an option to the diskspace desklet to choose if sizes should be shown decimal or binary, just like in the Nemo file manager settings.