### PR TITLE
Fix settings dialog not starting on Mint 20

### DIFF
--- a/analog-clock@cobinja.de/files/analog-clock@cobinja.de/3.0/desklet.js
+++ b/analog-clock@cobinja.de/files/analog-clock@cobinja.de/3.0/desklet.js
@@ -188,7 +188,7 @@ CobiAnalogClock.prototype = {
     
     this._displayTime = new GLib.DateTime();
 
-    this._menu.addAction(_("Settings"), Lang.bind(this, function() {Util.spawnCommandLine("python " + DESKLET_DIR + "/settings.py " + instanceId);}));
+    this._menu.addAction(_("Settings"), Lang.bind(this, function() {Util.spawnCommandLine(DESKLET_DIR + "/settings.py " + instanceId);}));
   },
   
   on_desklet_added_to_desktop: function(userEnabled) {

--- a/analog-clock@cobinja.de/files/analog-clock@cobinja.de/3.0/settings.py
+++ b/analog-clock@cobinja.de/files/analog-clock@cobinja.de/3.0/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#! /usr/bin/env python3
 #
 # settings.py
 # Copyright (C) 2013 Lars Mueller <cobinja@yahoo.de>


### PR DESCRIPTION
This fixes settings dialog startup that failed due to Mint 20 not having an executable called "python" anymore