### PR TITLE
Add capacity to monitor Usage and Memory in NVIDIA GPUs

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "system-monitor-graph@rcassani",
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
-    "version": "1.1",
+    "version": "1.2",
     "prevent-decorations": true
 }

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
@@ -16,7 +16,8 @@
         "options" : {
             "CPU" : "cpu",
             "RAM" : "ram",
-            "HDD" : "hdd"
+            "HDD" : "hdd",
+            "GPU" : "gpu"
         }
     },
     "filesystem": {
@@ -34,6 +35,34 @@
         "description": "Filesystem label",
         "tooltip": "Empty uses the filesystem name from df.",
         "dependency": "type=hdd"
+    },
+    "gpu-manufacturer": {
+        "type": "combobox",
+        "default": "nvidia",
+        "description": "GPU manufacturer",
+        "tooltip": "Select the GPU manufacturer.",
+        "options" : {
+            "NVIDIA" : "nvidia"
+        },
+        "dependency": "type=gpu"
+    },
+    "gpu-id": {
+        "type": "entry",
+        "default": "0",
+        "description": "Id of GPU to monitor",
+        "tooltip": "Check GPU id with nvidia-smi -L",
+        "dependency": "type=gpu"
+    },
+    "gpu-variable": {
+        "type": "combobox",
+        "default": "usage",
+        "description": "GPU variable to monitor",
+        "tooltip": "Select the GPU variable to monitor.",
+        "options" : {
+            "Usage"  : "usage",
+            "Memory" : "memory"
+        },
+        "dependency": "type=gpu"
     },
     "duration": {
         "type": "combobox",
@@ -101,6 +130,13 @@
         "default": "rgba(197,86,33,1.0)",
         "description": "Line color HDD",
         "dependency": "type=hdd",
+        "tooltip": "RGB or RGBA. Alpha is ignored"
+    },
+    "line-color-gpu": {
+        "type": "colorchooser",
+        "default": "rgba(197,86,133,1.0)",
+        "description": "Line color GPU",
+        "dependency": "type=gpu",
         "tooltip": "RGB or RGBA. Alpha is ignored"
     },
     "midline-color": {


### PR DESCRIPTION
- Adds the capacity to monitor Usage and Memory in NVIDIA GPUs.
- User indicates the `Id` of the GPU to monitor. Thus, multiple GPUs can be monitored simultaneously.  
- NVIDIA drivers are needed a the information is obtained with the `nvidia-smi` command.
- Place holders are placed in the JS code for further development to support GPUs from other manufacturers. 