### PR TITLE
[xkcd@rjanja] Settings for xkcd comic viewer

### DIFF
--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -76,6 +76,8 @@ XkcdDesklet.prototype = {
     updateUI: function(xkcdId) {
         let url, filename;
 
+        this._clutterBox.set_size(this.maxWidth, this.maxHeight)
+
         if (xkcdId === null || xkcdId === undefined) {
             url = 'http://www.xkcd.com/info.0.json';
             filename = this.save_path + '/temp.json'
@@ -108,7 +110,7 @@ XkcdDesklet.prototype = {
 
     set_tooltip: function(tip) {
         //global.log('set_tooltip');
-        if (tip !== null) {  
+        if (tip !== null) {
             this._photoFrame.tooltip_text = tip;
         }
         else {
@@ -129,10 +131,10 @@ XkcdDesklet.prototype = {
 
             let tempFile, jsonFile;
             let finalFilename = this.save_path + '/' + this.curXkcd.num + '.json';
-            
+
             if (cached !== true && filename != finalFilename) {
                 tempFile = Gio.file_new_for_path(filename);
-                
+
                 try {
                     jsonFile = Gio.file_new_for_path(finalFilename);
                     jsonFile.trash(null);
@@ -144,9 +146,9 @@ XkcdDesklet.prototype = {
                 }
                 catch (e) {}
             }
-            
+
             this.set_tooltip(null);
-            
+
             let imgFilename = this.save_path + '/' + this.curXkcd.num + '.png';
             let imgFile = Gio.file_new_for_path(imgFilename);
             if (imgFile.query_exists(null)) {
@@ -155,7 +157,7 @@ XkcdDesklet.prototype = {
             else {
                 this.download_file(this.curXkcd.img, imgFilename, Lang.bind(this, this.on_xkcd_downloaded));
             }
-            
+
         }
         else {
             //global.log('No joy, no json');
@@ -181,14 +183,14 @@ XkcdDesklet.prototype = {
     },
 
     _init: function(metadata, desklet_id){
-        try {            
+        try {
             Desklet.Desklet.prototype._init.call(this, metadata);
             this.metadata = metadata
             this.updateInProgress = false;
             this._files = [];
             this._xkcds = [];
             this._currentXkcd = null;
-            
+
             this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], desklet_id);
             this.settings.bind("max-height", "maxHeight", this._onSettingsChanged);
             this.settings.bind("max-width", "maxWidth", this._onSettingsChanged);
@@ -201,7 +203,7 @@ XkcdDesklet.prototype = {
             this._binLayout = new Clutter.BinLayout();
             this._clutterBox = new Clutter.Box();
             this._clutterTexture = new Clutter.Texture({
-                keep_aspect_ratio: true, 
+                keep_aspect_ratio: true,
                 filter_quality: this.metadata["quality"]});
             this._clutterTexture.connect('load-finished', Lang.bind(this, function(e) {
                 if (this.curXkcd && this.curXkcd['alt']) {
@@ -210,12 +212,12 @@ XkcdDesklet.prototype = {
             }));
             this._clutterTexture.set_load_async(true);
             this._clutterBox.set_layout_manager(this._binLayout);
-            this._clutterBox.set_width(this.metadata["width"]);
+
             this._clutterBox.add_actor(this._clutterTexture);
-            this._photoFrame.set_child(this._clutterBox);            
+            this._photoFrame.set_child(this._clutterBox);
             this.setContent(this._photoFrame);
-        
-            
+
+
             this._menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             this._menu.addAction(_("View latest xkcd"), Lang.bind(this, function() {
                 this._refresh(null);
@@ -232,8 +234,8 @@ XkcdDesklet.prototype = {
             }
 
             this.set_tooltip(null);
-            
-            
+
+
             let dir = Gio.file_new_for_path(this.save_path);
             if (dir.query_exists(null)) {
                 let fileEnum = dir.enumerate_children('standard::*', Gio.FileQueryInfoFlags.NONE, null);
@@ -249,7 +251,7 @@ XkcdDesklet.prototype = {
                 fileEnum.close(null);
             }
             this._xkcds.sort();
-            
+
             this.updateInProgress = false;
 
             if (this._xkcds.length == 0)
@@ -260,7 +262,7 @@ XkcdDesklet.prototype = {
             {
                 this._refresh(this._xkcds[this._xkcds.length - 1]);
             }
-            
+
             global.w = this._photoFrame;
             }
         catch (e) {
@@ -285,7 +287,7 @@ XkcdDesklet.prototype = {
         }
     },
 
-    on_desklet_clicked: function(event){  
+    on_desklet_clicked: function(event){
         try {
             if (event.get_button() == 1) {
                 this._update();

--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -169,7 +169,7 @@ XkcdDesklet.prototype = {
         return true;
     },
 
-    // taken from analog-clock@cobinja.de
+    // adapted from analog-clock@cobinja.de
     getImageFitting: function (imageFileName, maxWidth, maxHeight) {
         let width, height, fileInfo;
         [fileInfo, width, height] = GdkPixbuf.Pixbuf.get_file_info(imageFileName, null, null);
@@ -186,7 +186,11 @@ XkcdDesklet.prototype = {
 
         let actor = new Clutter.Actor({ width: maxWidth, height: maxHeight });
         actor.set_content(image);
-        actor.set_content_gravity(Clutter.Gravity.RESIZE_ASPECT)
+        if (this.keepCentered) {
+            actor.set_content_gravity(Clutter.ContentGravity.RESIZE_ASPECT);
+        } else {
+            actor.set_content_gravity(Clutter.ContentGravity.TOP_LEFT);
+        }
 
         return { actor: actor, origWidth: width, origHeight: height };
     },

--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -200,6 +200,11 @@ MyDesklet.prototype = {
             this._xkcds = [];
             this._currentXkcd = null;
             
+            this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], desklet_id);
+            this.settings.bind("max-height", "maxHeight", this._onSettingsChanged);
+            this.settings.bind("max-width", "maxWidth", this._onSettingsChanged);
+            this.settings.bind("refresh-interval", "refreshInterval", this._onSettingsChanged);
+            this.settings.bind("keep-centered", "keepCentered", this._onSettingsChanged);
 
             this.setHeader(_("xkcd"));
 
@@ -221,10 +226,6 @@ MyDesklet.prototype = {
             this._photoFrame.set_child(this._clutterBox);            
             this.setContent(this._photoFrame);
 
-            this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], desklet_id);
-            this.settings.bind("max-height", "max_height", this._onSettingsChanged);
-            this.settings.bind("keep-centered", "keep_centered", this._onSettingsChanged);
-        
             
             this._menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             this._menu.addAction(_("View latest xkcd"), Lang.bind(this, function() {

--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -99,31 +99,10 @@ MyDesklet.prototype = {
     set_tooltip: function(tip) {
         //global.log('set_tooltip');
         if (tip !== null) {
-            //this._photoFrame.hide();
-            //this._photoFrame.tooltip_text = '                                                                                                                                                                                            ';
-            
             this._photoFrame.tooltip_text = tip;
-            //this._photoFrame.show_tooltip();
-            //this._photoFrame.hide_tooltip();
-            //this._photoFrame.show();
-            //this._photoFrame.hover = false;
-            //this._photoFrame.reactive = true;
-            //this.emit('allocation-changed');
-            //this._photoFrame.tooltip_markup = '<span font_size="large" foreground="black" background="white">hello!</span>'; // ' + tip + '
-            //this._photoFrame.tooltip_markup = '<markup>hi there how are you hello!is cool!</markup>'; // ' + tip + '
-            //global.log(this._photoFrame.tooltip_markup);
-            //global.log(this._photoFrame.tooltip_window);
-            //this._photoFrame.show_help();
-            //this._photoFrame.trigger_tooltip_query();
         }
         else {
-            //this._photoFrame.hide_tooltip();
             this._photoFrame.tooltip_text = null;
-            //this._photoFrame.show_tooltip();
-            //this._photoFrame.tooltip_text = null;
-            //this._photoFrame.reactive = false;
-            //this._photoFrame.track_hover = true;
-            //this._photoFrame.hover = false;
         }
     },
 

--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -76,8 +76,6 @@ XkcdDesklet.prototype = {
     updateUI: function(xkcdId) {
         let url, filename;
 
-        this._clutterBox.set_size(this.maxWidth, this.maxHeight)
-
         if (xkcdId === null || xkcdId === undefined) {
             url = 'http://www.xkcd.com/info.0.json';
             filename = this.save_path + '/temp.json'
@@ -94,6 +92,18 @@ XkcdDesklet.prototype = {
                 this.download_file(url, filename, Lang.bind(this, this.on_json_downloaded));
             }
         }
+
+        // Constrain the image to the max width/height (without forcing it to upscale if it's smaller)
+        // Needs to be called when we know for sure that the texture is loaded
+        var outwh = this._clutterTexture.get_base_size();
+        var width = outwh[0];
+        var height = outwh[1];
+        if (width > this.maxWidth || height > this.maxHeight) {
+            this._clutterBox.set_size(this.maxWidth, this.maxHeight);
+        } else {
+            this._clutterBox.set_size(width, height);
+        }
+
         return true;
     },
 
@@ -153,7 +163,7 @@ XkcdDesklet.prototype = {
             let imgFile = Gio.file_new_for_path(imgFilename);
             if (imgFile.query_exists(null)) {
                 this.on_xkcd_downloaded(true, imgFilename, true);
-            }
+                }
             else {
                 this.download_file(this.curXkcd.img, imgFilename, Lang.bind(this, this.on_xkcd_downloaded));
             }

--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -25,11 +25,11 @@ function _(str) {
   return Gettext.dgettext(UUID, str);
 }
 
-function MyDesklet(metadata, desklet_id){
+function XkcdDesklet(metadata, desklet_id){
     this._init(metadata, desklet_id);
 }
 
-MyDesklet.prototype = {
+XkcdDesklet.prototype = {
     __proto__: Desklet.Desklet.prototype,
 
     download_file: function(url, localFilename, callback) {
@@ -288,6 +288,6 @@ MyDesklet.prototype = {
 }
 
 function main(metadata, desklet_id){
-    let desklet = new MyDesklet(metadata, desklet_id);
+    let desklet = new XkcdDesklet(metadata, desklet_id);
     return desklet;
 }

--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -10,6 +10,7 @@ const Util = imports.misc.util;
 
 const Tooltips = imports.ui.tooltips;
 const PopupMenu = imports.ui.popupMenu;
+const Settings = imports.ui.settings;
 const Cinnamon = imports.gi.Cinnamon;
 const Soup = imports.gi.Soup
 let session = new Soup.SessionAsync();
@@ -24,8 +25,8 @@ function _(str) {
   return Gettext.dgettext(UUID, str);
 }
 
-function MyDesklet(metadata){
-    this._init(metadata);
+function MyDesklet(metadata, desklet_id){
+    this._init(metadata, desklet_id);
 }
 
 MyDesklet.prototype = {
@@ -190,7 +191,7 @@ MyDesklet.prototype = {
         });
     },
 
-    _init: function(metadata){
+    _init: function(metadata, desklet_id){
         try {            
             Desklet.Desklet.prototype._init.call(this, metadata);
             this.metadata = metadata
@@ -220,6 +221,10 @@ MyDesklet.prototype = {
             this._photoFrame.set_child(this._clutterBox);            
             this.setContent(this._photoFrame);
 
+            this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], desklet_id);
+            this.settings.bind("max-height", "max_height", this._onSettingsChanged);
+            this.settings.bind("keep-centered", "keep_centered", this._onSettingsChanged);
+        
             
             this._menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             this._menu.addAction(_("View latest xkcd"), Lang.bind(this, function() {
@@ -266,12 +271,9 @@ MyDesklet.prototype = {
                 this.refresh(this._xkcds[this._xkcds.length - 1]);
                 this._timeoutId = Mainloop.timeout_add_seconds(5, Lang.bind(this, this.refresh));
             }
-
-            
             
             global.w = this._photoFrame;
-            
-        }
+            }
         catch (e) {
             global.logError(e);
         }
@@ -306,6 +308,6 @@ MyDesklet.prototype = {
 }
 
 function main(metadata, desklet_id){
-    let desklet = new MyDesklet(metadata);
+    let desklet = new MyDesklet(metadata, desklet_id);
     return desklet;
 }

--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -24,28 +24,29 @@ const UUID = "xkcd@rjanja";
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
 
 function _(str) {
-  return Gettext.dgettext(UUID, str);
+    return Gettext.dgettext(UUID, str);
 }
 
-function XkcdDesklet(metadata, desklet_id){
+function XkcdDesklet(metadata, desklet_id) {
     this._init(metadata, desklet_id);
 }
 
 XkcdDesklet.prototype = {
     __proto__: Desklet.Desklet.prototype,
 
-    download_file: function(url, localFilename, callback) {
+    download_file: function (url, localFilename, callback) {
         let outFile = Gio.file_new_for_path(localFilename);
         var outStream = new Gio.DataOutputStream({
-            base_stream:outFile.replace(null, false, Gio.FileCreateFlags.NONE, null)});
+            base_stream: outFile.replace(null, false, Gio.FileCreateFlags.NONE, null)
+        });
 
         var message = Soup.Message.new('GET', url);
-        session.queue_message(message, function(session, response) {
+        session.queue_message(message, function (session, response) {
             if (response.status_code !== Soup.KnownStatusCode.OK) {
-               global.log("Error during download: response code " + response.status_code
-                  + ": " + response.reason_phrase + " - " + response.response_body.data);
-               callback(false, null);
-               return true;
+                global.log("Error during download: response code " + response.status_code
+                    + ": " + response.reason_phrase + " - " + response.response_body.data);
+                callback(false, null);
+                return true;
             }
 
             try {
@@ -53,18 +54,18 @@ XkcdDesklet.prototype = {
                 outStream.close(null);
             }
             catch (e) {
-               global.logError("Site seems to be down. Error was:");
-               global.logError(e);
-               callback(false, null);
-               return true;
+                global.logError("Site seems to be down. Error was:");
+                global.logError(e);
+                callback(false, null);
+                return true;
             }
 
             callback(true, localFilename);
             return false;
-         });
+        });
     },
 
-    _refresh: function(xkcdId) {
+    _refresh: function (xkcdId) {
         // global.log("refreshing");
         if (this.updateInProgress) return true;
         this.updateInProgress = true;
@@ -75,7 +76,7 @@ XkcdDesklet.prototype = {
         return true;
     },
 
-    updateUI: function(xkcdId) {
+    updateUI: function (xkcdId) {
         let url, filename;
 
         if (xkcdId === null || xkcdId === undefined) {
@@ -108,11 +109,11 @@ XkcdDesklet.prototype = {
         }
     },
 
-    query_tooltip: function(widget, x, y, keyboard_mode, tooltip, user_data) {
+    query_tooltip: function (widget, x, y, keyboard_mode, tooltip, user_data) {
         global.log('query tooltip');
     },
 
-    set_tooltip: function(tip) {
+    set_tooltip: function (tip) {
         //global.log('set_tooltip');
         if (tip !== null) {
             this._photoFrame.tooltip_text = tip;
@@ -122,7 +123,7 @@ XkcdDesklet.prototype = {
         }
     },
 
-    on_json_downloaded: function(success, filename, cached) {
+    on_json_downloaded: function (success, filename, cached) {
         if (success) {
             this.curXkcd = JSON.parse(Cinnamon.get_file_contents_utf8_sync(filename));
 
@@ -143,12 +144,12 @@ XkcdDesklet.prototype = {
                     jsonFile = Gio.file_new_for_path(finalFilename);
                     jsonFile.trash(null);
                 }
-                catch (e) {}
+                catch (e) { }
 
                 try {
                     tempFile.set_display_name(this.curXkcd.num + '.json', null);
                 }
-                catch (e) {}
+                catch (e) { }
             }
 
             this.set_tooltip(null);
@@ -157,7 +158,7 @@ XkcdDesklet.prototype = {
             let imgFile = Gio.file_new_for_path(imgFilename);
             if (imgFile.query_exists(null)) {
                 this.on_xkcd_downloaded(true, imgFilename, true);
-                }
+            }
             else {
                 this.download_file(this.curXkcd.img, imgFilename, Lang.bind(this, this.on_xkcd_downloaded));
             }
@@ -175,7 +176,7 @@ XkcdDesklet.prototype = {
         [fileInfo, width, height] = GdkPixbuf.Pixbuf.get_file_info(imageFileName, null, null);
 
         let pixBuf = GdkPixbuf.Pixbuf.new_from_file_at_size(imageFileName, width, height);
-        
+
         let image = new Clutter.Image();
         image.set_data(
             pixBuf.get_pixels(),
@@ -195,14 +196,14 @@ XkcdDesklet.prototype = {
         return { actor: actor, origWidth: width, origHeight: height };
     },
 
-    on_xkcd_downloaded: function(success, file, cached) {
+    on_xkcd_downloaded: function (success, file, cached) {
         // TODO: add back animation
         this.updateInProgress = false;
         this._clutterImageActor = this.getImageFitting(file, this.maxWidth, this.maxHeight).actor;
         this._photoFrame.set_child(this._clutterImageActor);
     },
 
-    _init: function(metadata, desklet_id){
+    _init: function (metadata, desklet_id) {
         try {
             Desklet.Desklet.prototype._init.call(this, metadata);
             this.metadata = metadata
@@ -219,9 +220,9 @@ XkcdDesklet.prototype = {
 
             this.setHeader(_("xkcd"));
 
-            this._photoFrame = new St.Bin({style_class: 'xkcd-box', x_align: St.Align.START});
+            this._photoFrame = new St.Bin({ style_class: 'xkcd-box', x_align: St.Align.START });
             this._binLayout = new Clutter.BinLayout();
-            
+
             this._clutterImageActor = new Clutter.Actor();
 
             // Signal deprecated, no replacement :( 
@@ -231,17 +232,17 @@ XkcdDesklet.prototype = {
             //         this.set_tooltip(this.curXkcd.alt);
             //     }
             // }));
-            
+
 
             this._photoFrame.set_child(this._clutterImageActor);
             this.setContent(this._photoFrame);
 
 
             this._menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this._menu.addAction(_("View latest xkcd"), Lang.bind(this, function() {
+            this._menu.addAction(_("View latest xkcd"), Lang.bind(this, function () {
                 this._refresh(null);
             }));
-            this._menu.addAction(_("Open save folder"), Lang.bind(this, function() {
+            this._menu.addAction(_("Open save folder"), Lang.bind(this, function () {
                 Util.spawnCommandLine("xdg-open " + this.save_path);
             }));
 
@@ -273,24 +274,22 @@ XkcdDesklet.prototype = {
 
             this.updateInProgress = false;
 
-            if (this._xkcds.length == 0)
-            {
+            if (this._xkcds.length == 0) {
                 this._refresh(null);
             }
-            else
-            {
+            else {
                 this._refresh(this._xkcds[this._xkcds.length - 1]);
             }
 
             global.w = this._photoFrame;
-            }
+        }
         catch (e) {
             global.logError(e);
         }
         return true;
     },
 
-    _update: function(){
+    _update: function () {
         // Move to the next, older comic
         try {
             let idx = this._xkcds.indexOf(this._currentXkcd);
@@ -306,7 +305,7 @@ XkcdDesklet.prototype = {
         }
     },
 
-    on_desklet_clicked: function(event){
+    on_desklet_clicked: function (event) {
         try {
             if (event.get_button() == 1) {
                 this._update();
@@ -317,12 +316,12 @@ XkcdDesklet.prototype = {
         }
     },
 
-    _onSettingsChanged: function(event) {
+    _onSettingsChanged: function (event) {
         this._refresh();
     }
 }
 
-function main(metadata, desklet_id){
+function main(metadata, desklet_id) {
     let desklet = new XkcdDesklet(metadata, desklet_id);
     return desklet;
 }

--- a/xkcd@rjanja/files/xkcd@rjanja/metadata.json
+++ b/xkcd@rjanja/files/xkcd@rjanja/metadata.json
@@ -1,11 +1,11 @@
 {
- "uuid": "xkcd@rjanja",
- "name": "xkcd comics viewer",
- "description": "A viewer for today's xkcd comic",
- "minimum-decoration": 1,
- "directory":"~/Pictures/xkcd",
- "delay": 5,
- "quality": 2,
- "fade-delay": 0.3
+    "uuid": "xkcd@rjanja",
+    "name": "xkcd comics viewer",
+    "description": "A viewer for today's xkcd comic",
+    "minimum-decoration": 1,
+    "directory": "~/Pictures/xkcd",
+    "delay": 5,
+    "quality": 2,
+    "fade-delay": 0.3,
+    "last-edited": 1612628134
 }
-

--- a/xkcd@rjanja/files/xkcd@rjanja/metadata.json
+++ b/xkcd@rjanja/files/xkcd@rjanja/metadata.json
@@ -6,6 +6,5 @@
     "directory": "~/Pictures/xkcd",
     "delay": 5,
     "quality": 2,
-    "fade-delay": 0.3,
-    "last-edited": 1612628134
+    "fade-delay": 0.3
 }

--- a/xkcd@rjanja/files/xkcd@rjanja/settings-schema.json
+++ b/xkcd@rjanja/files/xkcd@rjanja/settings-schema.json
@@ -1,20 +1,20 @@
 {
     "max-height": {
         "type": "spinbutton",
-        "default": 90,
+        "default": 500,
         "min": 20,
-        "max": 4096,
-        "units": "px",
+        "max": 10000,
+        "units": "pixels",
         "description": "Maximum height",
         "tooltip": "Select the maximum height that the desklet can have.",
         "step": 1
     },
     "max-width": {
         "type": "spinbutton",
-        "default": 90,
+        "default": 1000,
         "min": 20,
-        "max": 4096,
-        "units": "px",
+        "max": 10000,
+        "units": "pixels",
         "description": "Maximum width",
         "tooltip": "Select the maximum width that the desklet can have.",
         "step": 1
@@ -24,9 +24,9 @@
         "default": 5,
         "min": 1,
         "max": 86400,
-        "units": "s",
+        "units": "seconds",
         "description": "Refresh interval",
-        "tooltip": "Select how frequently the applet should refresh. Set to 60 for 1 minute, 3600 for 1 hour, 86400 for 1 day.",
+        "tooltip": "Select how frequently the desklet should refresh. Set to 60 for 1 minute, 3600 for 1 hour, 86400 for 1 day.",
         "step": 1
     },
     "keep-centered": {

--- a/xkcd@rjanja/files/xkcd@rjanja/settings-schema.json
+++ b/xkcd@rjanja/files/xkcd@rjanja/settings-schema.json
@@ -1,0 +1,18 @@
+{
+    "max-height": {
+        "type": "spinbutton",
+        "default": 90,
+        "min": 20,
+        "max": 4096,
+        "units": "px",
+        "description": "Maximum height",
+        "tooltip": "Select the maximum height that the desklet can have.",
+        "step": 1
+    },
+    "keep-centered": {
+        "type": "switch",
+        "default": false,
+        "description": "Keep centered",
+        "tooltip": "Check this to keep the desklet in the center of the screen."
+    }
+}

--- a/xkcd@rjanja/files/xkcd@rjanja/settings-schema.json
+++ b/xkcd@rjanja/files/xkcd@rjanja/settings-schema.json
@@ -9,6 +9,26 @@
         "tooltip": "Select the maximum height that the desklet can have.",
         "step": 1
     },
+    "max-width": {
+        "type": "spinbutton",
+        "default": 90,
+        "min": 20,
+        "max": 4096,
+        "units": "px",
+        "description": "Maximum width",
+        "tooltip": "Select the maximum width that the desklet can have.",
+        "step": 1
+    },
+    "refresh-interval": {
+        "type": "spinbutton",
+        "default": 5,
+        "min": 1,
+        "max": 86400,
+        "units": "s",
+        "description": "Refresh interval",
+        "tooltip": "Select how frequently the applet should refresh. Set to 60 for 1 minute, 3600 for 1 hour, 86400 for 1 day.",
+        "step": 1
+    },
     "keep-centered": {
         "type": "switch",
         "default": false,


### PR DESCRIPTION
This desklet often becomes larger than the screen, as it doesn't have a maximum height and width option.
Furthermore, its readme instructs the user to just edit the metadata.json to configure the desklet. Which is... not very nice.

To fix these issues, I've added a settings window.
The settings are:

* maximum height
* maximum width
* refresh interval
* whether to keep the desklet centered (otherwise, keep it at the top left of its bounding box)

Working on this, I also migrated it to use ClutterImage instead of ClutterTexture (which is deprecated).

As of now, the main issue is getting the image to behave as expected:

- [ ]  only resize when at least one of the size limits is exceeded (so, don't resize if the image is smaller than the dedicated space)
- [ ]  set gravity to center when `keep-centered` is true, otherwise set gravity to top-left
- [ ]  add back tween animation that plays when the image is changed

There is still some unexpected behavior, I am probably misunderstanding the Clutter documentation. If anyone wants to help, do feel welcome to suggest edits.