### PR TITLE
Added font color chooser option to the cpuload@kimse desklet

### DIFF
--- a/cpuload@kimse/files/cpuload@kimse/desklet.js
+++ b/cpuload@kimse/files/cpuload@kimse/desklet.js
@@ -40,6 +40,7 @@ CpuLoadDesklet.prototype = {
         this.settings.bindProperty(Settings.BindingDirection.IN, 'refresh-interval', 'refresh_interval', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'design', 'design', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'circle', 'circle', this.on_setting_changed);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'font-color', 'font_color', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'color-theme', 'color_theme', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'static-theme-color', 'static_theme_color', this.on_setting_changed);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'show-background', 'show_background', this.on_setting_changed);
@@ -244,7 +245,8 @@ CpuLoadDesklet.prototype = {
      */
     getTextLabelStyle(font_size){
         return "font-size: " + font_size + "px;" +
-               "width:" + (this.cpu_container_size / global.ui_scale) + "px";
+               "width:" + (this.cpu_container_size / global.ui_scale) + "px;" +
+               "color:" + (this.font_color) + ";";
     },
 
     /**

--- a/cpuload@kimse/files/cpuload@kimse/settings-schema.json
+++ b/cpuload@kimse/files/cpuload@kimse/settings-schema.json
@@ -70,6 +70,11 @@
         "type": "header",
         "description": "Colors"
     },
+    "font-color": {
+        "type": "colorchooser",
+        "default": "rgba(255,255,255,1.0)",
+        "description": "Font color"
+    },
     "color-theme": {
         "type": "combobox",
         "default": "random",


### PR DESCRIPTION
A user requested an option to change the font color, so I added that, because it was simple to implement.

![font_color_1](https://user-images.githubusercontent.com/450038/136829268-2c4b9700-06cb-4bb9-a6c2-194c1a2effa7.png)

![font_color_2](https://user-images.githubusercontent.com/450038/136829284-2f7ba011-1363-4ab7-bd86-9725a6a5f00a.png)

Also would it be better, to call the option "Text color" instead of "Font color" ?

@schorschii care to comment :-) ?