### PR TITLE
Add function - on clicking desklet: Open system monitor

### DIFF
--- a/diskspace@schorschii/files/diskspace@schorschii/desklet.js
+++ b/diskspace@schorschii/files/diskspace@schorschii/desklet.js
@@ -395,9 +395,13 @@ MyDesklet.prototype = {
 		if(this.onclick_action == "filemanager") {
 			let fs = decodeURIComponent(this.filesystem.replace("file://", "").trim());
 			Util.spawnCommandLine("xdg-open " + '"' + fs + '"');
-		} else if(this.onclick_action == "partitionmanager") {
-			Util.spawnCommandLine("gnome-disks");
-		}
+		} else {
+                	if(this.onclick_action == "partitionmanager") {
+			    Util.spawnCommandLine("gnome-disks");
+                	} else if(this.onclick_action == "sysmonitor") {
+                        	Util.spawnCommandLine("gnome-system-monitor");
+                       		}
+			}
 	},
 
 	on_desklet_removed: function() {


### PR DESCRIPTION
Adds the option of opening the Gnome System Monitor when clicking on the desklet; this requires editing the settings-schema.json file as well, see other pull request