### PR TITLE
Adding `cookiecutter` template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name"    : "My Projetc",
+    "project_name"    : "My Project",
     "author_name"     : "ZenithClown",
 
     "UUID" : "{{ cookiecutter.project_name.lower().replace(' ', '_') }}@{{ cookiecutter.author_name }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,0 +1,8 @@
+{
+    "project_name"    : "My Projetc",
+    "author_name"     : "ZenithClown",
+
+    "UUID" : "{{ cookiecutter.project_name.lower().replace(' ', '_') }}@{{ cookiecutter.author_name }}",
+    "description" : "A short description of {{ cookiecutter.project_name }}.",
+    "prevent_decorations" : "Prevent Desklet Decorations (true/false)?"
+}

--- a/{{ cookiecutter.UUID }}/CHANGELOG.md
+++ b/{{ cookiecutter.UUID }}/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+<p align = "justify">All notable changes to <code><b>{{ cookiecutter.UUID }}</b></code> will be documented here. The format is based on <a href = "https://keepachangelog.com/en/1.0.0/">Keep a Changelog</a>, and this project adheres to <a href = "https://semver.org/spec/v2.0.0.html">Semantic Versioning</a>.</p>

--- a/{{ cookiecutter.UUID }}/README.md
+++ b/{{ cookiecutter.UUID }}/README.md
@@ -1,0 +1,3 @@
+# {{ cookiecutter.UUID }}
+
+<p align = "justify">{{ cookiecutter.description }}</p>

--- a/{{ cookiecutter.UUID }}/files/{{ cookiecutter.UUID }}/desklet.js
+++ b/{{ cookiecutter.UUID }}/files/{{ cookiecutter.UUID }}/desklet.js
@@ -1,0 +1,3 @@
+// main file for the desklet application
+const Desklet = imports.ui.desklet;
+

--- a/{{ cookiecutter.UUID }}/files/{{ cookiecutter.UUID }}/metadata.json
+++ b/{{ cookiecutter.UUID }}/files/{{ cookiecutter.UUID }}/metadata.json
@@ -1,0 +1,6 @@
+{
+    "uuid" : "{{ cookiecutter.UUID }}",
+    "name" : "{{ cookiecutter.project_name }}",
+    "description" : "{{ cookiecutter.description }}",
+    "pervent-decorations" : "{{ cookiecutter.prevent_decorations }}"
+}

--- a/{{ cookiecutter.UUID }}/info.json
+++ b/{{ cookiecutter.UUID }}/info.json
@@ -1,0 +1,6 @@
+{
+    "UUID" : "{{ cookiecutter.UUID }}",
+    "author" : "{{ cookiecutter.author_name }}",
+    "created_on" : "{% now 'utc', '%A, %B %e, %H:%M' %} (UTC)",
+    "short_description" : "{{ cookiecutter.description }}",
+}


### PR DESCRIPTION
<p align = "justify">The template is built to be used by <a href = "https://cookiecutter.readthedocs.io/en/1.7.3/README.html"><code>cookiecutter</code></a> - an excellent command-line utility to initialize a project from a template.</p>

### Prerequisite
<p align = "justify">Considering base level cinnamon flavored system, you may first install <code>pip</code>, followed by cookiecutter installation (to use this template).</p>

```shell
$ sudo apt install -y python3-pip
$ pip install cookiecutter
```

### Creating a Project from Remote URL
<p align = "justify">Once the utility is installed, initiate a project with <code>cookiecutter https://github.com/linuxmint/cinnamon-spices-desklets</code>, this will ask a series of questions to initialize the directory as follows.</p>

```shell
~/.local/share/cinnamon/desklets > cookiecutter https://github.com/linuxmint/cinnamon-spices-desklets                                                        21:43:22
project_name [My Project]: hello-world
author_name [ZenithClown]: 
UUID [hello-world@ZenithClown]: 
description [A short description of hello-world.]: A hello world cinnamon desklet application.  
prevent_decorations [Prevent Desklet Decorations (true/false)?]: true
~/.local/share/cinnamon/desklets > cd hello-world@ZenithClown                                                                                             1m 8s 21:44:48
~/.local/share/cinnamon/desklets/hello-world@ZenithClown > tree -ah                                                                                             21:44:56
.
├── [   0]  CHANGELOG.md
├── [4.0K]  hello-world@ZenithClown
│   ├── [  78]  desklet.js
│   └── [ 174]  metadata.json
├── [ 174]  info.json
└── [   0]  README.md

1 directory, 5 files
```
