### PR TITLE
Spawn gcalendar using Util.spawnCommandLineAsyncIO function

### DIFF
--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/lib/utility.js
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/lib/utility.js
@@ -49,15 +49,17 @@ function Event(eventLine, useTwentyFourHour) {
 };
 
 SpawnReader.prototype.spawn = function(path, command, func) {
-    // Remove 'gcalendar' from the command array as it is part of the writeEvents.sh
-    // Until a better solution to retrieve events from gcalendar use the writeEvents.sh
-    command.shift();
     let commandStr = command.join(" ");
-    // Using pipes to read the output sometimes leaves the command running and cause too many files opened
-    Util.spawnCommandLineAsync("bash " + DESKLET_DIR + "writeEvents.sh " + commandStr, () => {
-        let commandFileContents = Cinnamon.get_file_contents_utf8_sync(COMMAND_OUTPUT_FILE).toString();
-        func(commandFileContents);
-    });
+    Util.spawnCommandLineAsyncIO(
+        commandStr,
+        (stdout, stderr, exitCode) => {
+            if (exitCode == 0) {
+                func(stdout);
+            } else {
+                func("");
+            }
+        }
+    );
 };
 
 CalendarUtility.prototype.label = function(text, zoom, textColor, leftAlign = true, fontSize = 10) {

--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/writeEvents.sh
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/writeEvents.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/bash
-gcalendar "$@" > ~/.local/share/cinnamon/desklets/googleCalendar@javahelps.com/output.txt
-exit 0;


### PR DESCRIPTION
Hopefully `Util.spawnCommandLineAsyncIO` won't cause the `GLib.Error g-unix-error-quark: Too many open files` error.