### PR TITLE
system-monitor-graph@rcassani - Use asynchronous wait when taking measurements

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
@@ -7,7 +7,6 @@ const Cinnamon = imports.gi.Cinnamon;
 const Gio = imports.gi.Gio;
 const Cairo = imports.cairo;
 const St = imports.gi.St;
-//const Util = imports.misc.util;
 const GLib = imports.gi.GLib;
 const Gettext = imports.gettext;
 
@@ -100,11 +99,11 @@ SystemMonitorGraph.prototype = {
             this.hdd_hdd_tot = 0;
             // values to graph
             this.cpu_use     = 0;
-            this.gpu_use     = 0;
-            this.gpu_mem     = new Array(2).fill(0.0);
             this.ram_values  = new Array(2).fill(0.0);
             this.swap_values = new Array(2).fill(0.0);
             this.hdd_values  = new Array(4).fill(0.0);
+            this.gpu_use     = 0;
+            this.gpu_mem     = new Array(2).fill(0.0);
 
             // set colors
             switch (this.type) {

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "system-monitor-graph@rcassani",
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
-    "version": "1.3",
+    "version": "1.4",
     "prevent-decorations": true
 }


### PR DESCRIPTION
It fixes as perceptible pause when the GPU readings were used. 

This PR updates the desklet to use `wait_asynch` to wait for getting the different measurements (CPU, RAM, HDD, and GPU). The code refactoring  was inspired by the [diskspace@schorschii](https://github.com/linuxmint/cinnamon-spices-desklets/tree/master/diskspace%40schorschii/files/diskspace%40schorschii) desklet.

I have tested all the measurements except for `Swap`, as I don't have access to a system with swap partition. It would be good to test this before merging.






