### PR TITLE
xkcd@rjanja: Added support for localized special directories name 

### DIFF
--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -230,6 +230,22 @@ MyDesklet.prototype = {
             }));
 
             let dir_path = this.metadata["directory"];
+
+            // Replace special directory name if any, e.g. DIRECTORY_PICTURES/xkcd replaced by /home/username/Pictures/xkcd.
+            let special_dir_name = dir_path.substring(dir_path.indexOf("<") + 1, dir_path.indexOf(">"))
+            if (dir_path.indexOf("<") == 0 && special_dir_name != "") {
+                let special_dir_enumvalue = eval("GLib.UserDirectory." + special_dir_name)
+
+                // If invalid speciale dir name, get_user_special_dir falls back to desktop folder. Here we default to ~/Pictures
+                if(special_dir_enumvalue != undefined) {
+                    let special_dir_path = GLib.get_user_special_dir(special_dir_enumvalue)
+                    dir_path = dir_path.replace("<" + special_dir_name + ">", special_dir_path);
+                }
+                else {
+                    dir_path = dir_path.replace(/\<.*\>/g, "~/Pictures"); // Regex capture all between "< >"
+                }
+            }
+
             this.save_path = dir_path.replace('~', GLib.get_home_dir());
             let saveFolder = Gio.file_new_for_path(this.save_path);
             if (!saveFolder.query_exists(null)) {

--- a/xkcd@rjanja/files/xkcd@rjanja/metadata.json
+++ b/xkcd@rjanja/files/xkcd@rjanja/metadata.json
@@ -3,7 +3,7 @@
  "name": "xkcd comics viewer",
  "description": "A viewer for today's xkcd comic",
  "minimum-decoration": 1,
- "directory":"~/Pictures/xkcd",
+ "directory":"<DIRECTORY_PICTURES>/xkcd",
  "delay": 5,
  "quality": 2,
  "fade-delay": 0.3


### PR DESCRIPTION
@rjanja

The default savepath for images is `~/Pictures`. If your system was setup in another language, this folder may not exist, for example it's `~/Images` instead, in french.

With this PR, the default value for metadata.directory is now `"<DIRECTORY_PICTURES>/xkcd"`, which will find the right default picture folder on the system.

Possible values are the list of special directories found here https://gjs-docs.gnome.org/glib20~2.66.1/glib.userdirectory

Nb:
- Special directory is optional. `~/xkdc` or `Pictures/xkcd` will still work.
- Program looks for special name within `<...>` at the start of the path. 
- To use special name, path must start with it (`/home/<DIRECTORY_PICTURES>/xkcd` is not valid ; `<DIRECTORY_PICTURES>/xkcd` is valid)
- Invalid special name will be replaced by the default `~/Pictures`

