### PR TITLE
bbcwx@oak-wood.co.uk: Add option to set custom text shadow

### DIFF
--- a/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/desklet.js
+++ b/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/desklet.js
@@ -138,6 +138,8 @@ MyDesklet.prototype = {
       this.settings.bindProperty(Settings.BindingDirection.ONE_WAY,"borderwidth","borderwidth",this.updateStyle,null);
       this.settings.bindProperty(Settings.BindingDirection.ONE_WAY,"iconstyle","iconstyle",this.updateStyle,null);
       this.settings.bindProperty(Settings.BindingDirection.ONE_WAY,"citystyle","citystyle",this.updateStyle,null);
+      this.settings.bindProperty(Settings.BindingDirection.ONE_WAY,"textshadow","textshadow",this.updateStyle,null);
+      this.settings.bindProperty(Settings.BindingDirection.ONE_WAY,"shadowblur","shadowblur",this.updateStyle,null);
       // this change requires us to fetch new data:
       this.settings.bindProperty(Settings.BindingDirection.ONE_WAY,"stationID","stationID",this.changeStation,null);
       // this requires a change of API key and refetch data
@@ -379,7 +381,7 @@ MyDesklet.prototype = {
     if(fcap.pressure) {this.fwtable.add(this.fpressurelabel,{row:row,col:0}); row++}
     if(fcap.humidity) {this.fwtable.add(this.fhumiditylabel,{row:row,col:0}); row++}
     for(let f=0;f<this.no;f++) {
-      this.labels[f]=new St.Button({label: ''});
+      this.labels[f]=new St.Label();
       this.fwicons[f]=new St.Button();
       if(fcap.maximum_temperature) this.max[f]=new St.Label();
       if(fcap.minimum_temperature) this.min[f]=new St.Label();
@@ -601,6 +603,7 @@ MyDesklet.prototype = {
       this.banner.style='font-size: '+BBCWX_LINK_TEXT_SIZE*this.zoom+"px; color: " + this.textcolor;
       this.bannerpre.style='font-size: '+BBCWX_LINK_TEXT_SIZE*this.zoom+"px; color: " + this.textcolor;
       this.banner.set_style_class_name('bbcwx-link');
+      if (this.textshadow) this.window.style=this.window.style+";text-shadow: 1px 1px "+this.shadowblur+"px "+contrastingColor(this.textcolor);
     } else {
       this.window.set_style('');
       // set style_class and _header visibility according to
@@ -733,7 +736,7 @@ MyDesklet.prototype = {
     for(let f=0;f<this.no;f++)
     {
       let day = this.service.data.days[f];
-      this.labels[f].label=((this.daynames[day.day]) ? this.daynames[day.day] : '');
+      this.labels[f].text=((this.daynames[day.day]) ? this.daynames[day.day] : '');
       let fwiconimage = this._getIconImage(day.icon, BBCWX_ICON_HEIGHT*this.zoom);
       //fwiconimage.set_size(BBCWX_ICON_HEIGHT*this.iconprops.aspect*this.zoom, BBCWX_ICON_HEIGHT*this.zoom);
       this.fwicons[f].set_child(fwiconimage);
@@ -4315,6 +4318,30 @@ wxDriverMeteoBlue.prototype = {
 // Utility function to capitalise first letter of each word in a string
 String.prototype.ucwords = function() {
     return this.replace(/(?:^|\s)\S/g, function(a) { return a.toUpperCase(); });
+};
+
+// Choose automatically contrasting black or white shadow color dependent on text color
+function contrastingColor(color) {
+    return (luma(color) >= 165) ? '#000000' : '#ffffff';
+};
+
+function luma(color) {
+ // SMPTE C, Rec. 709 weightings
+    let hex = rgb2hex(color);
+    let r = parseInt(hex.slice(0, 2), 16);
+    let g = parseInt(hex.slice(2, 4), 16);
+    let b = parseInt(hex.slice(4), 16);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+function rgb2hex(rgb) {
+    let rgbSplit = rgb.split("(")[1].split(")")[0];
+    rgbSplit = rgbSplit.split(",");
+    let hex = rgbSplit.map(function(hexCol){                 //For each array element
+        hexCol = parseInt(hexCol).toString(16);              //Convert to a base16 string
+        return (hexCol.length == 1) ? "0" + hexCol : hexCol; //Add zero if we get only one character
+    })
+    return hex.join("");
 };
 
 function main(metadata, desklet_id){

--- a/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/po/bbcwx@oak-wood.co.uk.pot
+++ b/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/po/bbcwx@oak-wood.co.uk.pot
@@ -1074,6 +1074,22 @@ msgstr ""
 msgid "Set your location here"
 msgstr ""
 
+#. bbcwx@oak-wood.co.uk->settings-schema.json->textshadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. bbcwx@oak-wood.co.uk->settings-schema.json->textshadow->tooltip
+msgid "Check to add a text shadow"
+msgstr ""
+
+#. bbcwx@oak-wood.co.uk->settings-schema.json->shadowblur->description
+msgid "Shadow blur radius"
+msgstr ""
+
+#. bbcwx@oak-wood.co.uk->settings-schema.json->shadowblur->tooltip
+msgid "Set the text shadow sharp (1) or blurry (2-7)"
+msgstr ""
+
 #. bbcwx@oak-wood.co.uk->settings-schema.json->cornerradius->description
 msgid "Corner radius"
 msgstr ""

--- a/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/po/de.po
+++ b/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: bbcwx\n"
 "Report-Msgid-Bugs-To: chris@oak-wood.co.uk\n"
 "POT-Creation-Date: 2018-01-07 21:05+0000\n"
-"PO-Revision-Date: 2021-03-18 18:44+0100\n"
+"PO-Revision-Date: 2022-02-11 19:12+0100\n"
 "Last-Translator: sven <sven@liefgen.lu>\n"
 "Language-Team: German <de@li.org>\n"
 "Language: de\n"
@@ -1091,6 +1091,23 @@ msgstr "Ort"
 msgid "Set your location here"
 msgstr "Bestimme deinen Ort hier"
 
+#. bbcwx@oak-wood.co.uk->settings-schema.json->textshadow->description
+msgid "Text shadow"
+msgstr "Textschatten"
+
+#. bbcwx@oak-wood.co.uk->settings-schema.json->textshadow->tooltip
+msgid "Check to add a text shadow"
+msgstr "Aktivieren, um einen Textschatten zu erzeugen"
+
+#. bbcwx@oak-wood.co.uk->settings-schema.json->shadowblur->description
+msgid "Shadow blur radius"
+msgstr "Blur-Radius des Textschattens"
+
+#. bbcwx@oak-wood.co.uk->settings-schema.json->shadowblur->tooltip
+msgid "Set the text shadow sharp (1) or blurry (2-7)"
+msgstr ""
+"Bestimme den Blur-Effekt des Textschattens von scharf (1) bis weich (2-7)"
+
 #. bbcwx@oak-wood.co.uk->settings-schema.json->cornerradius->description
 msgid "Corner radius"
 msgstr "Eckenradius"
@@ -1143,6 +1160,12 @@ msgstr "Wetter Desklet"
 #. bbcwx@oak-wood.co.uk->metadata.json->description
 msgid "Display the weather from several web services on your desktop"
 msgstr "Zeigt das Wetter von mehreren Webdiensten auf Ihrem Desktop an"
+
+#~ msgid "Check to make the forecast better readable"
+#~ msgstr "Aktivieren, um die Vorhersage besser lesbar zu machen"
+
+#~ msgid "Click the button to select a new shadow color"
+#~ msgstr "Knopf anklicken, um eine neue Schattenfarbe auszuwählen"
 
 #~ msgid "Open Weather Map"
 #~ msgstr "Open Weather Map"

--- a/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/settings-schema.json
+++ b/bbcwx@oak-wood.co.uk/files/bbcwx@oak-wood.co.uk/settings-schema.json
@@ -285,6 +285,26 @@
     "tooltip" : "Click the button to select a new text color"
   },
 
+  "textshadow" : {
+    "type" : "switch",
+    "dependency": "overrideTheme",
+    "default" : false,
+    "description": "Text shadow",
+    "tooltip": "Check to add a text shadow"
+  },
+
+  "shadowblur" : {
+    "type" : "spinbutton",
+    "dependency": "overrideTheme",
+    "default" : 1.0,
+    "min" : 1,
+    "max" : 7.0,
+    "step" : 1,
+    "units" : "px",
+    "description" : "Shadow blur radius",
+    "tooltip" : "Set the text shadow sharp (1) or blurry (2-7)"
+  },
+
   "bgcolor" : {
     "type": "colorchooser",
     "indent": true,


### PR DESCRIPTION
This commit provides a settings option to set a text shadow with customizable blur-radius to implement a better contrast in conjunction with low background opacity.

closes #758