### PR TITLE
Option for binary and decimal prefixes in data sizes

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "system-monitor-graph@rcassani",
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
-    "version": "1.4",
+    "version": "1.5",
     "prevent-decorations": true
 }

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/da.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/da.po
@@ -38,8 +38,8 @@ msgid "Swap"
 msgstr "Swap"
 
 #: desklet.js:186
-msgid "GB free of"
-msgstr "GB ledig ud af"
+msgid "free of"
+msgstr "ledig ud af"
 
 #: desklet.js:187
 msgid "GB"

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/de.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/de.po
@@ -37,8 +37,8 @@ msgid "Swap"
 msgstr "Swap"
 
 #: desklet.js:172
-msgid "GB free of"
-msgstr "GB frei von"
+msgid "free of"
+msgstr "frei von"
 
 #: desklet.js:173
 msgid "GB"

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/es.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/es.po
@@ -33,8 +33,8 @@ msgid "GiB"
 msgstr "GiB"
 
 #: desklet.js:172
-msgid "GB free of"
-msgstr "GB libres de"
+msgid "free of"
+msgstr "libres de"
 
 #: desklet.js:173
 msgid "GB"

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/hu.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/hu.po
@@ -37,8 +37,8 @@ msgid "Swap"
 msgstr "Cserehely"
 
 #: desklet.js:186
-msgid "GB free of"
-msgstr "GB szabad, összesen:"
+msgid "free of"
+msgstr "szabad, összesen:"
 
 #: desklet.js:187
 msgid "GB"

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/it.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/it.po
@@ -38,8 +38,8 @@ msgid "Swap"
 msgstr "Swap"
 
 #: desklet.js:186
-msgid "GB free of"
-msgstr "GB liberi su"
+msgid "free of"
+msgstr "liberi su"
 
 #: desklet.js:187
 msgid "GB"

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/pt_BR.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/pt_BR.po
@@ -33,8 +33,8 @@ msgid "GiB"
 msgstr "GiB"
 
 #: desklet.js:172
-msgid "GB free of"
-msgstr "GB livres de"
+msgid "free of"
+msgstr "livres de"
 
 #: desklet.js:173
 msgid "GB"

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/system-monitor-graph@rcassani.pot
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/system-monitor-graph@rcassani.pot
@@ -37,7 +37,7 @@ msgid "Swap"
 msgstr ""
 
 #: desklet.js:186
-msgid "GB free of"
+msgid "free of"
 msgstr ""
 
 #: desklet.js:187

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
@@ -21,6 +21,39 @@
             "GPU" : "gpu"
         }
     },
+    "data-prefix-ram": {
+        "type": "combobox",
+        "default": 0,
+        "options": {
+            "Binary prefix or IEC (1 GiB = 1024³ bytes)" : 0,
+            "Decimal prefix (1 GB = 1000³ bytes)" : 1
+        },
+        "description": "Prefix for data units",
+        "tooltip": "Unit prefix for RAM size.",
+        "dependency": "type=ram"
+    },
+    "data-prefix-swap": {
+        "type": "combobox",
+        "default": 0,
+        "options": {
+            "Binary prefix or IEC (1 GiB = 1024³ bytes)" : 0,
+            "Decimal prefix (1 GB = 1000³ bytes)" : 1
+        },
+        "description": "Prefix for data units",
+        "tooltip": "Unit prefix for Swap size.",
+        "dependency": "type=swap"
+    },
+    "data-prefix-hdd": {
+        "type": "combobox",
+        "default": 0,
+        "options": {
+            "Binary prefix or IEC (1 GiB = 1024³ bytes)" : 0,
+            "Decimal prefix (1 GB = 1000³ bytes)" : 1
+        },
+        "description": "Prefix for data units",
+        "tooltip": "Unit prefix for Filesystem size.",
+        "dependency": "type=hdd"
+    },
     "filesystem": {
         "type": "filechooser",
         "default": "file:///",
@@ -63,6 +96,17 @@
             "Usage"  : "usage",
             "Memory" : "memory"
         },
+        "dependency": "type=gpu"
+    },
+    "data-prefix-gpumem": {
+        "type": "combobox",
+        "default": 0,
+        "options": {
+            "Binary prefix or IEC (1 GiB = 1024³ bytes)" : 0,
+            "Decimal prefix (1 GB = 1000³ bytes)" : 1
+        },
+        "description": "Prefix for data units",
+        "tooltip": "Unit prefix for GPU memory size.",
         "dependency": "type=gpu"
     },
     "duration": {


### PR DESCRIPTION
1. Add the option to present sizes of RAM, Swap, HDD and GPU memory in:
* Binary prefix or IEC (1 GiB = 1024³ bytes), or
* Decimal prefix (1 GB = 1000³ bytes)

Ping: @PRSoftware