### PR TITLE
[xkcd@rjanja] Fix for mint 21

### DIFF
--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -7,6 +7,8 @@ const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
 const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
+const GdkPixbuf = imports.gi.GdkPixbuf;
+const Cogl = imports.gi.Cogl;
 
 const Tooltips = imports.ui.tooltips;
 const PopupMenu = imports.ui.popupMenu;
@@ -46,7 +48,9 @@ MyDesklet.prototype = {
             }
 
             try {
-                Cinnamon.write_soup_message_to_stream(outStream, message);
+                let contents = message.response_body.flatten().get_as_bytes();  // For Soup 2.4
+                // let contents = message.response_body.flatten();              // For Soup 3.0
+                outStream.write_bytes(contents, null);
                 outStream.close(null);
             }
             catch (e) {
@@ -69,6 +73,7 @@ MyDesklet.prototype = {
 
         if (this._timeoutId) {
             Mainloop.source_remove(this._timeoutId);
+            delete this._timeoutId
         }
 
         if (xkcdId === null || xkcdId === undefined) {
@@ -96,34 +101,6 @@ MyDesklet.prototype = {
     },
 
     set_tooltip: function(tip) {
-        //global.log('set_tooltip');
-        if (tip !== null) {
-            //this._photoFrame.hide();
-            //this._photoFrame.tooltip_text = '                                                                                                                                                                                            ';
-            
-            this._photoFrame.tooltip_text = tip;
-            //this._photoFrame.show_tooltip();
-            //this._photoFrame.hide_tooltip();
-            //this._photoFrame.show();
-            //this._photoFrame.hover = false;
-            //this._photoFrame.reactive = true;
-            //this.emit('allocation-changed');
-            //this._photoFrame.tooltip_markup = '<span font_size="large" foreground="black" background="white">hello!</span>'; // ' + tip + '
-            //this._photoFrame.tooltip_markup = '<markup>hi there how are you hello!is cool!</markup>'; // ' + tip + '
-            //global.log(this._photoFrame.tooltip_markup);
-            //global.log(this._photoFrame.tooltip_window);
-            //this._photoFrame.show_help();
-            //this._photoFrame.trigger_tooltip_query();
-        }
-        else {
-            //this._photoFrame.hide_tooltip();
-            this._photoFrame.tooltip_text = null;
-            //this._photoFrame.show_tooltip();
-            //this._photoFrame.tooltip_text = null;
-            //this._photoFrame.reactive = false;
-            //this._photoFrame.track_hover = true;
-            //this._photoFrame.hover = false;
-        }
     },
 
     on_json_downloaded: function(success, filename, cached) {
@@ -174,18 +151,25 @@ MyDesklet.prototype = {
     },
 
     on_xkcd_downloaded: function(success, file, cached) {
-        Tweener.addTween(this._clutterTexture, { opacity: 0,
+        Tweener.addTween(this._image, { opacity: 0,
             time: this.metadata["fade-delay"],
             transition: 'easeInSine',
             onComplete: Lang.bind(this, function() {
                 this.updateInProgress = false;
-                if (this._clutterTexture.set_from_file(file)) {
-                    this._photoFrame.set_child(this._clutterBox);
+                let pixbuf = GdkPixbuf.Pixbuf.new_from_file(file);
+                if (pixbuf != null) {
+                    this._image.set_data(pixbuf.get_pixels(),
+                        pixbuf.get_has_alpha() ?
+                        Cogl.PixelFormat.RGBA_8888 :
+                        Cogl.PixelFormat.RGB_888,
+                        pixbuf.get_width(),
+                        pixbuf.get_height(),
+                        pixbuf.get_rowstride());
+                    this._imageFrame.set_width(pixbuf.get_width())
+                    this._imageFrame.set_height(pixbuf.get_height())
+                } else {
+                    global.logError("Error reading file : " + file)
                 }
-                Tweener.addTween(this._clutterTexture, { opacity: 255,
-                    time: this.metadata["fade-delay"],
-                    transition: 'easeInSine'
-                });
             })
         });
     },
@@ -202,24 +186,10 @@ MyDesklet.prototype = {
 
             this.setHeader(_("xkcd"));
 
-            this._photoFrame = new St.Bin({style_class: 'xkcd-box', x_align: St.Align.START});
-            this._binLayout = new Clutter.BinLayout();
-            this._clutterBox = new Clutter.Box();
-            this._clutterTexture = new Clutter.Texture({
-                keep_aspect_ratio: true, 
-                filter_quality: this.metadata["quality"]});
-            this._clutterTexture.connect('load-finished', Lang.bind(this, function(e) {
-                if (this.curXkcd && this.curXkcd['alt']) {
-                    this.set_tooltip(this.curXkcd.alt);
-                }
-            }));
-            this._clutterTexture.set_load_async(true);
-            this._clutterBox.set_layout_manager(this._binLayout);
-            this._clutterBox.set_width(this.metadata["width"]);
-            this._clutterBox.add_actor(this._clutterTexture);
-            this._photoFrame.set_child(this._clutterBox);            
-            this.setContent(this._photoFrame);
-
+            this._image = new Clutter.Image();
+            this._imageFrame = new Clutter.Actor({width: 0, height: 0})
+            this._imageFrame.set_content(this._image)
+            this.setContent(this._imageFrame)
             
             this._menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             this._menu.addAction(_("View latest xkcd"), Lang.bind(this, function() {
@@ -280,13 +250,8 @@ MyDesklet.prototype = {
             else
             {
                 this.refresh(this._xkcds[this._xkcds.length - 1]);
-                this._timeoutId = Mainloop.timeout_add_seconds(5, Lang.bind(this, this.refresh));
-            }
-
-            
-            
-            global.w = this._photoFrame;
-            
+                this._timeoutId = Mainloop.timeout_add_seconds(5, Lang.bind(this, this.refresh, null));
+            }            
         }
         catch (e) {
             global.logError(e);


### PR DESCRIPTION
The desklet is broken on mint 21 due to newer version of CJS:
 * newest Clutter version removed `Clutter.Texture` : Replaced `Clutter.Texture` by `Clutter.Image` (for display the comic) + `GdkPixbuf` for loading image from file.
 * newest Soup version removed `Cinnamon.write_soup_message_to_stream(...)` : fixed using `stream.write_bytes()`

Also removed useless and now broken tooltip part

Also fixed warning about `Mainloop.source_remove()` that showed up in Cinnamon log due to `this._timeoutId` not being unset.
 
Nb: I couldn't find which versions are used by CJS exactly. Looks like Soup 2.4 and Clutter above 7.

Nb 2 : Clutter project is now EOL (https://blogs.gnome.org/clutter/) so eventually it will have to be replaced.

Tested under Mint 20 and 21