### PR TITLE
[quoteOfTheDay@tinnu] Allow usage of multiple parameters for fortune command

### DIFF
--- a/quoteOfTheDay@tinnu/files/quoteOfTheDay@tinnu/3.2/desklet.js
+++ b/quoteOfTheDay@tinnu/files/quoteOfTheDay@tinnu/3.2/desklet.js
@@ -132,11 +132,11 @@ MyDesklet.prototype = {
                 Util.spawn_async(["fortune", file_path], Lang.bind(this, this._setNewQuote));
             }
             else {
-                Util.spawn_async(["fortune", this.fortuneParams, file_path], Lang.bind(this, this._setNewQuote));
+                Util.spawn_async(["fortune", ...this.fortuneParams.split(' '), file_path], Lang.bind(this, this._setNewQuote));
             }
         }
         else { // don't pass a file to fortune
-            Util.spawn_async(["fortune", this.fortuneParams], Lang.bind(this, this._setNewQuote));
+            Util.spawn_async(["fortune", ...this.fortuneParams.split(' ')], Lang.bind(this, this._setNewQuote));
         }
     },
 

--- a/quoteOfTheDay@tinnu/files/quoteOfTheDay@tinnu/3.6/desklet.js
+++ b/quoteOfTheDay@tinnu/files/quoteOfTheDay@tinnu/3.6/desklet.js
@@ -133,11 +133,11 @@ MyDesklet.prototype = {
                 Util.spawn_async(["fortune", file_path], Lang.bind(this, this._setNewQuote));
             }
             else {
-                Util.spawn_async(["fortune", this.fortuneParams, file_path], Lang.bind(this, this._setNewQuote));
+                Util.spawn_async(["fortune", ...this.fortuneParams.split(' '), file_path], Lang.bind(this, this._setNewQuote));
             }
         }
         else { // don't pass a file to fortune
-            Util.spawn_async(["fortune", this.fortuneParams], Lang.bind(this, this._setNewQuote));
+            Util.spawn_async(["fortune", ...this.fortuneParams.split(' ')], Lang.bind(this, this._setNewQuote));
         }
     },
 

--- a/quoteOfTheDay@tinnu/files/quoteOfTheDay@tinnu/desklet.js
+++ b/quoteOfTheDay@tinnu/files/quoteOfTheDay@tinnu/desklet.js
@@ -117,11 +117,11 @@ MyDesklet.prototype = {
                 Util.spawn_async(["fortune", this.file], Lang.bind(this, this._setNewQuote));
             }
             else {
-                Util.spawn_async(["fortune", this.fortuneParams, this.file], Lang.bind(this, this._setNewQuote));
+                Util.spawn_async(["fortune", ...this.fortuneParams.split(' '), this.file], Lang.bind(this, this._setNewQuote));
             }
         }
         else { // don't pass a file to fortune
-            Util.spawn_async(["fortune", this.fortuneParams], Lang.bind(this, this._setNewQuote));
+            Util.spawn_async(["fortune", ...this.fortuneParams.split(' ')], Lang.bind(this, this._setNewQuote));
         }
     },
 


### PR DESCRIPTION
This PR fixes #825.

The parameters entered get split on spaces, and the resulting array is then merged with the other `argv` arguments (by using the spread operator).
The only downside of this is that regular expressions (using the `-m pattern` option) cannot include spaces. If there are any other ideas on how to split the parameter list please let me know.