### PR TITLE
yfquotes@thegli: add setting to select the version of YF Quotes API

### DIFF
--- a/yfquotes@thegli/README.md
+++ b/yfquotes@thegli/README.md
@@ -24,6 +24,21 @@ Check out the desklet configuration settings, and choose the data refresh period
 
 ## Release Notes
 
+### 0.8.4 - May 8, 2023
+
+Features:
+
+- new setting to select the version of Yahoo Finance Quotes API
+- update Danish translation (courtesy of [Alan01](https://github.com/Alan01))
+- update Hungarian translation (courtesy of [KAMI911](https://github.com/KAMI911))
+- update Italian translation (courtesy of [Dragone2](https://github.com/Dragone2))
+
+### 0.8.3 - September 15, 2022
+
+Bugfixes:
+
+- add support for libsoup3 (courtesy of [fredcw](https://github.com/fredcw))
+
 ### 0.8.2 - June 8, 2022
 
 Bugfixes:
@@ -48,11 +63,11 @@ Bugfixes:
 
 Features:
 
-- add Russian translation
+- add Russian translation (courtesy of [sulonetskyy](https://github.com/sulonetskyy))
 
 ### 0.7.0 - January 10, 2022
 
-Features:
+Features (courtesy of [sulonetskyy](https://github.com/sulonetskyy)):
 
 - add symbolic trend change icons instead of .svg
 - add configurable trend change colors instead of hardcoded colors

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -65,15 +65,13 @@ YahooFinanceQuoteUtils.prototype = {
     }
 };
 
-let YahooFinanceQuoteReader = function () {
-};
+let YahooFinanceQuoteReader = function () {};
 
 YahooFinanceQuoteReader.prototype = {
     constructor : YahooFinanceQuoteReader,
-    yahooQueryBaseUrl : "https://query1.finance.yahoo.com/v7/finance/quote?symbols=",
     
-    getAsyncResponse : function(quoteSymbols, callback) {
-        const requestUrl = this.createYahooQueryUrl(quoteSymbols);
+    getAsyncResponse : function(quoteSymbols, apiVersion, callback) {
+        const requestUrl = this.createYahooQueryUrl(apiVersion, quoteSymbols);
         const errorBegin="{\"quoteResponse\":{\"result\":[],\"error\":\"";
         const errorEnd = "\"}}";
         
@@ -111,8 +109,8 @@ YahooFinanceQuoteReader.prototype = {
         }
     },
     
-    createYahooQueryUrl : function (quoteSymbols) {
-        return this.yahooQueryBaseUrl + quoteSymbols.join(",");
+    createYahooQueryUrl : function (apiVersion, quoteSymbols) {
+        return "https://query1.finance.yahoo.com/v" + apiVersion + "/finance/quote?symbols=" + quoteSymbols.join(",");
     }
 };
 
@@ -352,6 +350,8 @@ StockQuoteDesklet.prototype = {
             this.onDisplayChanged, null);
         this.settings.bindProperty(Settings.BindingDirection.IN, "transparency", "transparency",
             this.onDisplayChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "apiVersion", "apiVersion",
+            this.onSettingsChanged, null);
         this.settings.bindProperty(Settings.BindingDirection.IN, "delayMinutes", "delayMinutes",
             this.onSettingsChanged, null);
         this.settings.bindProperty(Settings.BindingDirection.IN, "showLastUpdateTimestamp", "showLastUpdateTimestamp",
@@ -469,9 +469,10 @@ StockQuoteDesklet.prototype = {
     
     onUpdate : function () {
         const quoteSymbols = this.quoteSymbolsText.split("\n");
+        const yfApiVersion = this.apiVersion ? this.apiVersion : "6";
         try {
             const _that = this;
-            this.quoteReader.getAsyncResponse(quoteSymbols, function(response) {
+            this.quoteReader.getAsyncResponse(quoteSymbols, yfApiVersion, function(response) {
                 let parsedResponse = JSON.parse(response);
                 _that.render([parsedResponse.quoteResponse.result, parsedResponse.quoteResponse.error]);
                 _that.setUpdateTimer();

--- a/yfquotes@thegli/files/yfquotes@thegli/metadata.json
+++ b/yfquotes@thegli/files/yfquotes@thegli/metadata.json
@@ -3,6 +3,6 @@
     "name": "Yahoo Finance Quotes",
     "prevent-decorations": true,
     "max-instances": "10",
-    "version": "0.8.2",
+    "version": "0.8.4",
     "uuid": "yfquotes@thegli"
 }

--- a/yfquotes@thegli/files/yfquotes@thegli/po/de.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/de.po
@@ -1,5 +1,5 @@
 # German translation for Yahoo Finance Quotes Desklet
-# Copyright (C) 2021 Thomas Egli
+# Copyright (C) 2023 Thomas Egli
 # This file is distributed under the same license as the Yahoo Finance Quotes Desklet package.
 #
 msgid ""
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-03-18 19:25+0100\n"
-"PO-Revision-Date: 2022-05-16 18:00+0100\n"
+"PO-Revision-Date: 2023-05-08 21:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
@@ -16,23 +16,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#: desklet.js:87
+#: desklet.js:92 desklet.js:106
 msgid "Yahoo Finance service not available!"
 msgstr "Yahoo Finance Service nicht verfügbar!"
 
-#: desklet.js:416
+#: desklet.js:438
 msgid "Updated at "
 msgstr "Aktualisiert um "
 
-#: desklet.js:423
+#: desklet.js:445
 msgid "Error: "
 msgstr "Fehler: "
 
-#: desklet.js:467
+#: desklet.js:490
 msgid "Cannot display quotes information for symbols: "
 msgstr "Finanzdaten können nicht angezeigt werden für die Symbole: "
 
-#: desklet.js:468
+#: desklet.js:491
 msgid "The following error occurred: "
 msgstr "Folgender Fehler ist aufgetreten: "
 
@@ -137,6 +137,22 @@ msgstr "Hintergrund Transparenz"
 #. settings-schema.json->transparency->tooltip
 msgid "The higher the value, the more solid the desklet background."
 msgstr "Je grösser der Wert, desto deckender der Desklet Hintergrund."
+
+#. settings-schema.json->apiVersion->options
+msgid "V6"
+msgstr "V6"
+
+#. settings-schema.json->apiVersion->options
+msgid "V7"
+msgstr "V7"
+
+#. settings-schema.json->apiVersion->description
+msgid "Yahoo Finance Quotes API version"
+msgstr "Yahoo Finance Quotes API Version"
+
+#. settings-schema.json->apiVersion->tooltip
+msgid "Try different version if data requests fail with error."
+msgstr "Version ändern, falls Datenabfragen fehlschlagen"
 
 #. settings-schema.json->delayMinutes->units
 msgid "minutes"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/yfquotes@thegli.pot
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/yfquotes@thegli.pot
@@ -1,5 +1,5 @@
 # Yahoo Finance Quotes Desklet
-# Copyright (C) 2021 Thomas Egli
+# Copyright (C) 2023 Thomas Egli
 # This file is distributed under the same license as the Yahoo Finance Quotes Desklet package.
 #
 #, fuzzy
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-18 18:52+0200\n"
-"PO-Revision-Date: 2022-05-16 23:48+0200\n"
+"POT-Creation-Date: 2023-05-08 21:58+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -16,23 +16,23 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: desklet.js:87
+#: desklet.js:92 desklet.js:106
 msgid "Yahoo Finance service not available!"
 msgstr ""
 
-#: desklet.js:416
+#: desklet.js:438
 msgid "Updated at "
 msgstr ""
 
-#: desklet.js:423
+#: desklet.js:445
 msgid "Error: "
 msgstr ""
 
-#: desklet.js:467
+#: desklet.js:490
 msgid "Cannot display quotes information for symbols: "
 msgstr ""
 
-#: desklet.js:468
+#: desklet.js:491
 msgid "The following error occurred: "
 msgstr ""
 
@@ -134,6 +134,22 @@ msgstr ""
 
 #. settings-schema.json->transparency->tooltip
 msgid "The higher the value, the more solid the desklet background."
+msgstr ""
+
+#. settings-schema.json->apiVersion->options
+msgid "V6"
+msgstr ""
+
+#. settings-schema.json->apiVersion->options
+msgid "V7"
+msgstr ""
+
+#. settings-schema.json->apiVersion->description
+msgid "Yahoo Finance Quotes API version"
+msgstr ""
+
+#. settings-schema.json->apiVersion->tooltip
+msgid "Try different version if data requests fail with error."
 msgstr ""
 
 #. settings-schema.json->delayMinutes->units

--- a/yfquotes@thegli/files/yfquotes@thegli/settings-schema.json
+++ b/yfquotes@thegli/files/yfquotes@thegli/settings-schema.json
@@ -30,7 +30,7 @@
     "dataUpdateSection": {
       "type": "section",
       "title": "Data Updates",
-      "keys": ["delayMinutes", "showLastUpdateTimestamp"]
+      "keys": ["apiVersion", "delayMinutes", "showLastUpdateTimestamp"]
     },
     "detailsNameSection": {
       "type": "section",
@@ -111,6 +111,16 @@
     "step": 0.05,
     "description": "Background transparency",
     "tooltip": "The higher the value, the more solid the desklet background."
+  },
+  "apiVersion": {
+    "type": "radiogroup",
+    "default": "6",
+    "options": {
+      "V6": "6",
+      "V7": "7"
+    },
+    "description": "Yahoo Finance Quotes API version",
+    "tooltip": "Try different version if data requests fail with error."
   },
   "delayMinutes": {
     "type": "spinbutton",


### PR DESCRIPTION
Add a configuration setting to choose the API version of Yahoo Finance Quotes.
Set default to version 6, as the current version 7 - which was used until now - caused problems recently.