### PR TITLE
avoid Array.toString() error messages

### DIFF
--- a/notes@schorschii/files/notes@schorschii/desklet.js
+++ b/notes@schorschii/files/notes@schorschii/desklet.js
@@ -13,6 +13,7 @@ const Cogl = imports.gi.Cogl;
 const Gio = imports.gi.Gio;
 const PopupMenu = imports.ui.popupMenu;
 const Gettext = imports.gettext;
+const ByteArray = imports.byteArray;
 
 const UUID = "notes@schorschii";
 const DESKLET_ROOT = imports.ui.deskletManager.deskletMeta[UUID].path;
@@ -96,7 +97,7 @@ MyDesklet.prototype = {
 			try {
 				let [success, contents, tag] = file.load_contents_finish(response);
 				if(success) {
-					let lines = contents.toString().split('\n');
+					let lines = ByteArray.toString(contents).split('\n');
 					for(var i = 0;i < lines.length;i++) {
 						let fields = lines[i].split(',');
 						if(fields.length != 9) { continue; }
@@ -137,7 +138,7 @@ MyDesklet.prototype = {
 			try {
 				let [success, contents, tag] = file.load_contents_finish(response);
 				if(success) {
-					this.notecontent = contents.toString();
+					this.notecontent = ByteArray.toString(contents);
 				} else {
 					// error reading file - maybe the file does not exist
 					this.notecontent = _("Can't read text file.\nSelect a file in settings.\n\nClick here to edit.");


### PR DESCRIPTION
This fix avoids Array.toString() warning messages appearing in ~/.xsession-errors, like:

```
(cinnamon:2062): Gjs-WARNING **: 23:25:36.963: Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array).
(Note that array.toString() may have been called implicitly.)
```

Thanks to @claudiux for bringing this up.

---

To the Mint maintainer merging this PR: please also have a look at https://github.com/linuxmint/cinnamon-spices-desklets/pull/841 and https://github.com/linuxmint/cinnamon-spices-desklets/pull/830. They are now waiting since months...