### PR TITLE
InternetTimeDesklet@stefan: Fix timezone for accurate Beat Time calculation

### DIFF
--- a/InternetTimeDesklet@stefan/files/InternetTimeDesklet@stefan/desklet.js
+++ b/InternetTimeDesklet@stefan/files/InternetTimeDesklet@stefan/desklet.js
@@ -74,9 +74,9 @@ NetBeatDesklet.prototype = {
 
 	refresh: function() {
 		let d = new Date();
-		let h = d.getHours();
-		let m = d.getMinutes();
-		let s = d.getSeconds();
+		let h = d.getUTCHours() + 1;
+		let m = d.getUTCMinutes();
+		let s = d.getUTCSeconds();
 		//let tzoff = 60 + d.getTimezoneOffset();
 		//let beats = ('000' + Math.floor((s + (m + tzoff) * 60 + h * 3600) / 86.4) % 1000).slice(-3);
 


### PR DESCRIPTION
Change the hour/minute/second variable assignments to explicitly be in UTC format. Also, add one hour to the "getUTCHours()" call, as "Biel Mean Time" (BMT), which Beat Time is based upon, is defined by Swatch as UTC+1.

Previously this was calling Date's getHours/getMinutes/getSeconds function family, which returns _LOCAL_ time. This had the effect of the Beat time returned by this desklet **always** being incorrect unless your computer's time is set to the UTC+1 timezone.

This commit fixes that and ensures that the correct universal Beat Time will be displayed regardless of the user's timezone.

Original author of this desklet is @stefan12O 