### PR TITLE
system-monitor-graph@rcassani: Fix Stuttering

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "system-monitor-graph@rcassani",
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
-    "version": "1.5",
+    "version": "1.6",
     "prevent-decorations": true
 }


### PR DESCRIPTION
Hi @rcassani , we noticed that `subprocess.init(null)` causes microstutters on our desktops, see #932. This PR fixes the issue like in my diskspace desklet (#937).

With this change, the values are read directly from files using Gio's `load_contents_async` instead of spawning `head` or `cat` subprocesses to read it.

For scenarios where this is not possible (NVIDIA GPU monitoring), I switched `subprocess.wait_async` to `load_contents_async` and `load_contents_finish` which seems to be the correct way to read subprocess output async, as described [here in the Gio docs](https://docs.gtk.org/gio/method.Subprocess.communicate_utf8_async.html).