### PR TITLE
calendar@schorschii improvements

### DIFF
--- a/calendar@schorschii/README.md
+++ b/calendar@schorschii/README.md
@@ -1,0 +1,11 @@
+# Calendar Desklet
+A simple local calendar desklet that can display the number of today's appointments from an ical/ics file.
+
+## Usage With Thunderbird
+You can e.g. configure the Thunderbird calendar to save your appointments in an ics file.
+
+1. Create an empty file on your computer, e.g. `/home/<username>/calendar.ics`.
+2. Create a new calendar in Thunderbird using this file.
+   - In the "New Calendar" dialog, choose "Network".
+   - As address, enter the URL path to the file on your computer, e.g. `file:///home/<username>/calendar.ics`.
+3. Choose the file in the desklet settings. The desklet will now display the number of today's appointments in the ics file.

--- a/calendar@schorschii/files/calendar@schorschii/metadata.json
+++ b/calendar@schorschii/files/calendar@schorschii/metadata.json
@@ -3,5 +3,5 @@
     "max-instances": "10",
     "description": "A calendar desklet that can display the number of today's appointments from an ical file.",
     "name": "Calendar",
-    "version": "1.3"
+    "version": "1.4"
 }

--- a/calendar@schorschii/files/calendar@schorschii/metadata.json
+++ b/calendar@schorschii/files/calendar@schorschii/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "calendar@schorschii",
     "max-instances": "10",
-    "description": "A calendar desklet that can display the number of today's appointments from an ical file.",
+    "description": "A calendar desklet that can display the number of today's appointments from an ical/ics file.",
     "name": "Calendar",
-    "version": "1.4"
+    "version": "1.5"
 }

--- a/calendar@schorschii/files/calendar@schorschii/po/ca.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/ca.po
@@ -175,17 +175,17 @@ msgstr ""
 "camp següent."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Camí al fitxer ical"
+msgid "Path to ical/ics file"
+msgstr "Camí al fitxer ical/ics"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Seleccioneu el vostre fitxer ical per llegir el nombre de cites d'avui.\n"
+"Seleccioneu el vostre fitxer ical o ics per llegir la quantitat de cites d'avui.\n"
 "\n"
 "Podeu configurar Lightning (el connector de Thunderbird) per desar el vostre "
 "calendari a un fitxer ical."

--- a/calendar@schorschii/files/calendar@schorschii/po/calendar@schorschii.pot
+++ b/calendar@schorschii/files/calendar@schorschii/po/calendar@schorschii.pot
@@ -167,12 +167,12 @@ msgid ""
 msgstr ""
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
+msgid "Path to ical/ics file"
 msgstr ""
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar in an ical file."
 msgstr ""

--- a/calendar@schorschii/files/calendar@schorschii/po/da.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/da.po
@@ -171,17 +171,17 @@ msgstr ""
 "i feltet nedenunder."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Sti til iCal-fil"
+msgid "Path to ical/ics file"
+msgstr "Sti til iCal/ics-fil"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Vælg iCal-filen, hvorfra antallet af aftaler skal indlæses.\n"
+"Vælg din ical- eller ics-fil for at læse antallet af aftaler i dag.\n"
 "\n"
 "Du kan konfigurere Lightning (Thunderbird-tilføjelsen) til at gemme din "
 "kalender som en iCal-fil."

--- a/calendar@schorschii/files/calendar@schorschii/po/de.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/de.po
@@ -175,17 +175,17 @@ msgstr ""
 "darunter auswählen."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Pfad zur ical-Datei"
+msgid "Path to ical/ics file"
+msgstr "Pfad zur ical/ics-Datei"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Wählen Sie die ical-Datei aus, aus welcher die Anzahl der heutigen Termine "
+"Wählen Sie die ical- oder ics-Datei aus, aus welcher die Anzahl der heutigen Termine "
 "ausgelesen werden soll.\n"
 "\n"
 "Sie können Lightning (das Thunderbird Add-On) so konfigurieren, dass es die "

--- a/calendar@schorschii/files/calendar@schorschii/po/es.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/es.po
@@ -175,17 +175,17 @@ msgstr ""
 "el campo inferior."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Ruta al archivo ical"
+msgid "Path to ical/ics file"
+msgstr "Ruta al archivo ical/ics"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Seleccione su archivo ical para leer la cantidad de compromisos de hoy.\n"
+"Seleccione su archivo ical o ics para leer la cantidad de citas hoy.\n"
 "\n"
 "Puede configurar Lightning (el complemento de Thunderbird) para guardar su "
 "calendario en un archivo ical."

--- a/calendar@schorschii/files/calendar@schorschii/po/hu.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/hu.po
@@ -163,16 +163,16 @@ msgid "Checking this box allows you to set an ical file to parse in the field be
 msgstr "Ennek a négyzetnek a bejelölésével az alábbi mezőben megadhat egy importálandó ical fájlt."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Elérési útvonal az ical fájlhoz"
+msgid "Path to ical/ics file"
+msgstr "Elérési útvonal az ical/ics fájlhoz"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar in an ical file."
 msgstr ""
-"Válassza ki az ical fájlt a mai találkozók mennyiségének beolvasásához.\n"
+"Válassza ki az ical vagy ics fájlt a mai találkozók számának olvasásához.\n"
 "\n"
 "Beállíthatja a Lightning-et (a Thunderbird kiegészítőjét), hogy a naptárat egy ical fájlba mentse."
 

--- a/calendar@schorschii/files/calendar@schorschii/po/it.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/it.po
@@ -174,17 +174,17 @@ msgstr ""
 "nel campo sottostante."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Percorso del file ical"
+msgid "Path to ical/ics file"
+msgstr "Percorso del file ical/ics"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Seleziona il tuo file ical per leggere la quantità di appuntamenti oggi.\n"
+"Seleziona il tuo file ical o ics per leggere il numero di appuntamenti di oggi.\n"
 "\n"
 "Puoi configurare Lightning (il componente aggiuntivo di Thunderbird) per "
 "salvare il tuo calendario in un file ical."

--- a/calendar@schorschii/files/calendar@schorschii/po/pt_BR.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/pt_BR.po
@@ -173,18 +173,17 @@ msgstr ""
 "abaixo para ser analisado."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Endereço do arquivo .ics"
+msgid "Path to ical/ics file"
+msgstr "Endereço do arquivo .ical/.ics"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Selecione o seu arquivo .ics para saber a quantidade de compromissos no dia "
-"de hoje.\n"
+"Selecione seu arquivo ical ou ics para ler a quantidade de compromissos hoje.\n"
 "\n"
 "Você pode configurar o salvamento do seu calendário em um arquivo .ics no "
 "Lightning (um complemento para o Thunderbird)."

--- a/calendar@schorschii/files/calendar@schorschii/po/ro.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/ro.po
@@ -163,16 +163,16 @@ msgid "Checking this box allows you to set an ical file to parse in the field be
 msgstr "Dacă bifezi această casetă, poți seta un fișier ical care să fie analizat în câmpul de mai jos."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Calea de acces la fișierul ical"
+msgid "Path to ical/ics file"
+msgstr "Calea de acces la fișierul ical/ics"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar in an ical file."
 msgstr ""
-"Selectează fișierul ta ical pentru citirea sumei numirilor de astăzi.\n"
+"Selectați fișierul ical sau ics pentru a citi numărul de întâlniri de astăzi.\n"
 "\n"
 "Poți configura Lightning (add-on-ul Thunderbird) pentru a îți salva calendarul într-un fișier ical."
 

--- a/calendar@schorschii/files/calendar@schorschii/po/sk.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/sk.po
@@ -180,17 +180,17 @@ msgstr ""
 "ical, ktorý sa má analyzovať."
 
 #. settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Cesta k súboru ical"
+msgid "Path to ical/ics file"
+msgstr "Cesta k súboru ical/ics"
 
 #. settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Vyberte váš súbor ical, z ktorého sa má čítať počet dnešných schôdzok.\n"
+"Vyberte si súbor ical alebo ics, aby ste si mohli prečítať počet stretnutí dnes.\n"
 "\n"
 "Môžete nastaviť Lightning (doplnok aplikácie Thunderbird), ktorý uloží váš "
 "kalendár do súboru ical."

--- a/calendar@schorschii/files/calendar@schorschii/po/sv.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/sv.po
@@ -170,17 +170,17 @@ msgid ""
 msgstr "Aktivering låter dig ange en iCal-fil som tolkas i fältet nedan."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "Sökväg till iCal-filen"
+msgid "Path to ical/ics file"
+msgstr "Sökväg till iCal/ics-filen"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Välj iCal-fil för inläsning av dagens inbokade händelser.\n"
+"Välj din ical- eller ics-fil för att läsa antalet möten idag.\n"
 "\n"
 "Du kan konfigurera Lightning (Thunderbird-tillägg) till att spara din "
 "kalender i en iCal-fil."

--- a/calendar@schorschii/files/calendar@schorschii/po/tr.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/tr.po
@@ -172,17 +172,17 @@ msgstr ""
 "seçmenize izin verir."
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "ical dosyasının yolu"
+msgid "Path to ical/ics file"
+msgstr "ical/ics dosyasının yolu"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"Bugün randevu miktarını okumak için ical dosyanızı seçin.\n"
+"Bugünkü randevu miktarını okumak için ical veya ics dosyanızı seçin.\n"
 "\n"
 "Takviminizi bir ical dosyasına kaydetmek için Lightning'i (Thunderbird "
 "eklentisini) yapılandırabilirsiniz."

--- a/calendar@schorschii/files/calendar@schorschii/po/zh_CN.po
+++ b/calendar@schorschii/files/calendar@schorschii/po/zh_CN.po
@@ -167,17 +167,17 @@ msgid ""
 msgstr "选中此项允许您在下面的方框中设置要解析的ical文件。"
 
 #. calendar@schorschii->settings-schema.json->ical-file->description
-msgid "Path to ical file"
-msgstr "ical文件的路径"
+msgid "Path to ical/ics file"
+msgstr "ical/ics文件的路径"
 
 #. calendar@schorschii->settings-schema.json->ical-file->tooltip
 msgid ""
-"Select your ical file for reading the amount of appointments today.\n"
+"Select your ical or ics file for reading the amount of appointments today.\n"
 "\n"
 "You can configure Lightning (the Thunderbird Add-On) to save your calendar "
 "in an ical file."
 msgstr ""
-"选择您用于阅读今天预约数量的ical文件。\n"
+"选择您的 ical 或 ics 文件以读取今天的预约数量。\n"
 "\n"
 "您可以配置Lightning(Thunderbird扩展)将保存您的日历在ical文件中。"
 

--- a/calendar@schorschii/files/calendar@schorschii/settings-schema.json
+++ b/calendar@schorschii/files/calendar@schorschii/settings-schema.json
@@ -66,8 +66,8 @@
     "ical-file": {
         "type": "filechooser",
         "default": "",
-        "description": "Path to ical file",
-        "tooltip": "Select your ical file for reading the amount of appointments today.\n\nYou can configure Lightning (the Thunderbird Add-On) to save your calendar in an ical file.",
+        "description": "Path to ical/ics file",
+        "tooltip": "Select your ical or ics file for reading the amount of appointments today.\n\nYou can configure Lightning (the Thunderbird Add-On) to save your calendar in an ical file.",
         "allow-none" : true
     },
 


### PR DESCRIPTION
- replaced synchronous file read with async alternative to avoid warning in the desklet manager
- mentioned .ics as more common file extension besides .ical
- added readme how to configure Thunderbird to write the calendar into an .ics file for use with the desklet