### PR TITLE
diskspace@schorschii: option to display reserved blocks as free space

### DIFF
--- a/diskspace@schorschii/files/diskspace@schorschii/desklet.js
+++ b/diskspace@schorschii/files/diskspace@schorschii/desklet.js
@@ -41,6 +41,7 @@ MyDesklet.prototype = {
 		// initialize settings
 		this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], desklet_id);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "size-prefix", "size_prefix", this.on_setting_changed);
+		this.settings.bindProperty(Settings.BindingDirection.IN, "reserved-blocks-as-used-space", "reserved_blocks_as_used_space", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "hide-decorations", "hide_decorations", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "use-custom-label", "use_custom_label", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "custom-label", "custom_label", this.on_setting_changed);
@@ -149,7 +150,12 @@ MyDesklet.prototype = {
 						let fileInfo = file.query_filesystem_info_finish(response);
 						avail = fileInfo.get_attribute_uint64(Gio.FILE_ATTRIBUTE_FILESYSTEM_FREE);
 						size = fileInfo.get_attribute_uint64(Gio.FILE_ATTRIBUTE_FILESYSTEM_SIZE);
-						use = size - avail;
+						if(this.reserved_blocks_as_used_space) {
+							use = size - avail;
+						} else {
+							use = fileInfo.get_attribute_uint64(Gio.FILE_ATTRIBUTE_FILESYSTEM_USED);
+							global.log(use.toString());
+						}
 						percentString = Math.round(use * 100 / size) + "%";
 					} catch(err) {
 						// e.g. file not found (= not mounted)

--- a/diskspace@schorschii/files/diskspace@schorschii/desklet.js
+++ b/diskspace@schorschii/files/diskspace@schorschii/desklet.js
@@ -154,7 +154,6 @@ MyDesklet.prototype = {
 							use = size - avail;
 						} else {
 							use = fileInfo.get_attribute_uint64(Gio.FILE_ATTRIBUTE_FILESYSTEM_USED);
-							global.log(use.toString());
 						}
 						percentString = Math.round(use * 100 / size) + "%";
 					} catch(err) {

--- a/diskspace@schorschii/files/diskspace@schorschii/metadata.json
+++ b/diskspace@schorschii/files/diskspace@schorschii/metadata.json
@@ -2,6 +2,6 @@
     "max-instances": "10",
     "description": "Displays the usage of a filesystem or RAM.",
     "name": "Disk Space",
-    "version": "1.14",
+    "version": "1.15",
     "uuid": "diskspace@schorschii"
 }

--- a/diskspace@schorschii/files/diskspace@schorschii/po/de.po
+++ b/diskspace@schorschii/files/diskspace@schorschii/po/de.po
@@ -53,6 +53,12 @@ msgstr "Dateisystem, welches angezeigt werden soll"
 msgid "Select the file system, which you want to monitor."
 msgstr "Wählen Sie das Dateisystem, welches Sie anzeigen möchten."
 
+msgid "Show reserved blocks as used space"
+msgstr "Zeige reservierte Blöcke als verwendeten Speicher"
+
+msgid "Reserved blocks are useable for the root user only and that's why displayed as used space by default."
+msgstr "Reservierte Blöcke sind nur vom root-Benutzer verwendbar und daher standardmäßig ausgeblendet."
+
 msgid "Visual"
 msgstr "Visuelle Einstellungen"
 

--- a/diskspace@schorschii/files/diskspace@schorschii/po/diskspace@schorschii.pot
+++ b/diskspace@schorschii/files/diskspace@schorschii/po/diskspace@schorschii.pot
@@ -51,6 +51,12 @@ msgstr ""
 msgid "Select the file system, which you want to monitor."
 msgstr ""
 
+msgid "Show reserved blocks as used space"
+msgstr ""
+
+msgid "Reserved blocks are useable for the root user only and that's why displayed as used space by default."
+msgstr ""
+
 msgid "Visual"
 msgstr ""
 

--- a/diskspace@schorschii/files/diskspace@schorschii/settings-schema.json
+++ b/diskspace@schorschii/files/diskspace@schorschii/settings-schema.json
@@ -39,6 +39,21 @@
             "Nothing" : "nothing"
         }
     },
+    "size-prefix": {
+        "type": "combobox",
+        "default": "binary",
+        "description": "Size Prefix",
+        "options" : {
+            "Decimal" : "decimal",
+            "Binary": "binary"
+        }
+    },
+    "reserved-blocks-as-used-space": {
+        "type": "checkbox",
+        "description": "Show reserved blocks as used space",
+        "tooltip": "Reserved blocks are useable for the root user only and that's why displayed as used space by default.",
+        "default": true
+    },
 
     "head2": {
         "type": "header",
@@ -65,15 +80,6 @@
             "Free and total space": "free-size",
             "Total and free space": "size-free",
             "No text": "none"
-        }
-    },
-    "size-prefix": {
-        "type": "combobox",
-        "default": "binary",
-        "description": "Size Prefix",
-        "options" : {
-            "Decimal" : "decimal",
-            "Binary": "binary"
         }
     },
     "hide-decorations": {


### PR DESCRIPTION
See discussion #940. This adds an option to let the user decide how to display reserved blocks.