### PR TITLE
hostcheck@schorschii: Readme update

### DIFF
--- a/hostcheck@schorschii/README.md
+++ b/hostcheck@schorschii/README.md
@@ -2,7 +2,6 @@
 - Monitor a host via ping or HTTP(S)
 - Optionally shows desktop notifications when state changed
 - `/bin/ping` must be available for ping checks
-- `/usr/bin/curl` must be available for HTTP(S) checks
 
 ## Contributions
 - first version by _schorschii_


### PR DESCRIPTION
`curl` is not necessary anymore in v1.4.

Forgot this small change in #1026 , sorry.