### PR TITLE
dual-datetime@rcalixte: Version 1.2.1

### DIFF
--- a/dual-datetime@rcalixte/CHANGELOG.md
+++ b/dual-datetime@rcalixte/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+### 1.2.1
+* Update default time size to 5
+* Update default date size to 2.5
+* Update default alignments to center for date and time
+
 ### 1.2
 
 * A blank or invalid format string now reset to locale defaults

--- a/dual-datetime@rcalixte/files/dual-datetime@rcalixte/5.4/settings-schema.json
+++ b/dual-datetime@rcalixte/files/dual-datetime@rcalixte/5.4/settings-schema.json
@@ -18,7 +18,7 @@
     "time_align1": {
         "type": "combobox",
         "description": "Time Alignment",
-        "default": "left",
+        "default": "center",
         "dependency": "title_align=vertical",
         "options": {
             "Left": "left",
@@ -29,7 +29,7 @@
     "time_yalign1": {
         "type": "combobox",
         "description": "Time Alignment",
-        "default": "left",
+        "default": "center",
         "tooltip": "This value only applies if the this time value is a smaller size than the other",
         "dependency": "title_align!=vertical",
         "options": {
@@ -54,7 +54,7 @@
     "time_size1": {
         "type": "scale",
         "description": "Font Size",
-        "default": 2,
+        "default": 5,
         "min": 0.5,
         "max": 20,
         "step": 0.1,
@@ -80,7 +80,7 @@
     "time_align2": {
         "type": "combobox",
         "description": "Time Alignment",
-        "default": "left",
+        "default": "center",
         "dependency": "title_align=vertical",
         "options": {
             "Left": "left",
@@ -91,7 +91,7 @@
     "time_yalign2": {
         "type": "combobox",
         "description": "Time Alignment",
-        "default": "left",
+        "default": "center",
         "tooltip": "This value only applies if the this time value is a smaller size than the other",
         "dependency": "title_align!=vertical",
         "options": {
@@ -116,7 +116,7 @@
     "time_size2": {
         "type": "scale",
         "description": "Font Size",
-        "default": 2,
+        "default": 2.5,
         "min": 0.5,
         "max": 20,
         "step": 0.1,

--- a/dual-datetime@rcalixte/files/dual-datetime@rcalixte/metadata.json
+++ b/dual-datetime@rcalixte/files/dual-datetime@rcalixte/metadata.json
@@ -5,9 +5,11 @@
     "cinnamon-version": [
         "5.4",
         "5.6",
-        "5.8"
+        "5.8",
+        "6.0",
+        "6.2"
     ],
     "multiversion": true,
     "max-instances": "10",
-    "version": "1.1"
+    "version": "1.2.1"
 }


### PR DESCRIPTION
* Update default time size to 5
* Update default date size to 2.5
* Update default alignments to center for date and time