### PR TITLE
cpuload@kimse: Display full bar for NaN cpu_utilization

### DIFF
--- a/cpuload@kimse/files/cpuload@kimse/desklet.js
+++ b/cpuload@kimse/files/cpuload@kimse/desklet.js
@@ -283,6 +283,10 @@ CpuLoadDesklet.prototype = {
         let cpu_active_time = this.cpus_utilization[core];
         let color = this.getCpuColor(core);
 
+        if (isNaN(cpu_active_time)) {
+            cpu_active_time = 100;
+        }
+
         canvas.set_size(this.cpu_container_size, this.cpu_container_size);
         canvas.connect('draw', function(canvas, cr, width, height) {
 


### PR DESCRIPTION
@schorschii

Reduces the impact of this bug: https://github.com/linuxmint/cinnamon-spices-desklets/issues/1205

All ok:
![image](https://github.com/linuxmint/cinnamon-spices-desklets/assets/32168886/ded5449d-3938-4bc4-bb17-14f850a3d754)
All NaN:
![image](https://github.com/linuxmint/cinnamon-spices-desklets/assets/32168886/95c7979f-16ef-4a58-b32a-a2559aab0087)
Some NaN:
![image](https://github.com/linuxmint/cinnamon-spices-desklets/assets/32168886/51a9ad16-0565-4b61-badc-f970562e27e9)
