### PR TITLE
Reorder setting label's text, style and position

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
@@ -325,21 +325,21 @@ SystemMonitorGraph.prototype = {
             return false;
         });
 
-        // text position and content
+        // labels: set text, style and position
+        this.text1.set_text(text1);
+        this.text1.style = "font-size: " + text1_size + "px;"
+                         + "color: " + this.text_color + ";";
         this.text1.set_position(
             Math.round(unit_size),
             Math.round((2.5 * unit_size) - this.text1.get_height())
         );
-        this.text1.set_text(text1);
-        this.text1.style = "font-size: " + text1_size + "px;"
+        this.text2.set_text(text2);
+        this.text2.style = "font-size: " + text2_size + "px;"
                          + "color: " + this.text_color + ";";
         this.text2.set_position(
             Math.round(this.text1.get_width() + (2 * unit_size)),
             Math.round((2.5 * unit_size) - this.text2.get_height())
         );
-        this.text2.set_text(text2);
-        this.text2.style = "font-size: " + text2_size + "px;"
-                         + "color: " + this.text_color + ";";
         this.text3.set_text(text3);
         this.text3.style = "font-size: " + text3_size + "px;"
                          + "color: " + this.text_color + ";";


### PR DESCRIPTION
This pull request fixes the #1100 for the `system-monitor-graph@rcassani` Desklet

I was able to replicate the reported issue, the it was not observed anymore with the proposed changes.

It seems that the order in the `text`, `style` and `positions` are set for `St.Labels` is important. Although I could not find an explanation for this.