### PR TITLE
notes@schorschii: Allow in desklet note taking

### DIFF
--- a/notes@schorschii/files/notes@schorschii/desklet.js
+++ b/notes@schorschii/files/notes@schorschii/desklet.js
@@ -78,6 +78,8 @@ MyDesklet.prototype = {
 		this.settings.bindProperty(Settings.BindingDirection.IN, "bg-color", "customBgColor", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "file", "file", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "edit-cmd", "editCmd", this.on_setting_changed);
+		this.settings.bindProperty(Settings.BindingDirection.IN, "note-taking-method", "noteTakingMethod", this.on_setting_changed);
+		this.settings.bindProperty(Settings.BindingDirection.IN, "note-text", "noteText", this.on_setting_changed);
 
 		// initialize desklet gui
 		this.setupUI();
@@ -154,6 +156,12 @@ MyDesklet.prototype = {
 	},
 
 	loadText: function(reloadGraphics = false) {
+		if (this.noteTakingMethod == "desklet") {
+			this.notecontent = this.noteText;
+			this.refreshDesklet(reloadGraphics);
+			return;
+		}
+
 		// get notes text file path
 		this.finalPath = decodeURIComponent(this.file.replace("file://", ""));
 		if(this.finalPath == "") this.finalPath = "note.txt"; // in home dir
@@ -278,7 +286,7 @@ MyDesklet.prototype = {
 	},
 
 	on_desklet_clicked: function() {
-		if(this.editCmd != "") {
+		if(this.noteTakingMethod == "file" && this.editCmd != "") {
 			Util.spawnCommandLine(this.editCmd.replace("%f", '"'+this.finalPath+'"'));
 		}
 	},

--- a/notes@schorschii/files/notes@schorschii/metadata.json
+++ b/notes@schorschii/files/notes@schorschii/metadata.json
@@ -2,6 +2,6 @@
     "max-instances": "10",
     "description": "A desklet to display notes including various themes.",
     "name": "Note",
-    "version": "2.3",
+    "version": "2.4",
     "uuid": "notes@schorschii"
 }

--- a/notes@schorschii/files/notes@schorschii/po/ca.po
+++ b/notes@schorschii/files/notes@schorschii/po/ca.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2023-08-04 19:52+0200\n"
 "Last-Translator: Daniel <d3vf4n@tutanota.com>\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Actualitza"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Feu clic aquí per editar-ho."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Llibreta"
 

--- a/notes@schorschii/files/notes@schorschii/po/ca.po
+++ b/notes@schorschii/files/notes@schorschii/po/ca.po
@@ -1,8 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-04 15:06+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2023-08-04 19:52+0200\n"
 "Last-Translator: Daniel <d3vf4n@tutanota.com>\n"
 "Language-Team: \n"
@@ -16,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:130
+#: desklet.js:133
 msgid "Refresh"
 msgstr "Actualitza"
 
-#: desklet.js:143
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -32,7 +33,7 @@ msgstr ""
 "\n"
 "Feu clic aquí per editar-ho."
 
-#: desklet.js:263
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Llibreta"
 
@@ -42,16 +43,37 @@ msgstr ""
 "Una miniaplicació d'escriptori senzilla per mostrar notes amb diversos temes."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Nota"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Ajusts per notes@schorschii"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "General"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Visual"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Color del text"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Alçada de la miniaplicació d'escriptori"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -69,9 +91,9 @@ msgstr "Ordre per editar aquesta nota (amb el clic del ratolí)"
 msgid "%f will replaced by the text file path."
 msgstr "%f se substituirà amb el camí al fitxer de text."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Visual"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -299,12 +321,6 @@ msgstr ""
 "Augmenta o disminueix la mida de la nota\n"
 "amb aquest factor de canvi d'escala."
 
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Etiqueta de miniaplicació d'escriptori personalitzada (només és visible si "
-"les decoracions estan habilitades)"
-
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
 msgstr "Utilitza una etiqueta de miniaplicació d'escriptori personalitzada"
@@ -327,15 +343,3 @@ msgstr ""
 "Establiu aquí la vostra etiqueta personalitzada. Aquest camp no està "
 "disponible\n"
 "a menys que la casella de selecció de dalt estigui habilitada."
-
-#~ msgid "Note size"
-#~ msgstr "Mida de la nota"
-
-#~ msgid "White"
-#~ msgstr "Blanc"
-
-#~ msgid "Desklet width"
-#~ msgstr "Amplada de la miniaplicació d'escriptori"
-
-#~ msgid "Desklet height"
-#~ msgstr "Alçada de la miniaplicació d'escriptori"

--- a/notes@schorschii/files/notes@schorschii/po/da.po
+++ b/notes@schorschii/files/notes@schorschii/po/da.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2023-12-08 07:45+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Dansk-gruppen <dansk@dansk-gruppen.dk>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Opdatér"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Klik her for at redigere."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Notesblok"
 

--- a/notes@schorschii/files/notes@schorschii/po/da.po
+++ b/notes@schorschii/files/notes@schorschii/po/da.po
@@ -1,8 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-04 15:06+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2023-12-08 07:45+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Dansk-gruppen <dansk@dansk-gruppen.dk>\n"
@@ -16,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:130
+#: desklet.js:133
 msgid "Refresh"
 msgstr "Opdatér"
 
-#: desklet.js:143
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -32,7 +33,7 @@ msgstr ""
 "\n"
 "Klik her for at redigere."
 
-#: desklet.js:263
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Notesblok"
 
@@ -42,16 +43,37 @@ msgstr ""
 "Et enkelt skrivebordsprogram til visning af noter med forskellige temaer."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Note"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Indstillinger"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Generel"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Visuel"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Tekstfarve"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Skrivebordsprogrammets størrelse"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -69,9 +91,9 @@ msgstr "Kommando til redigering af denne note (ved museklik)"
 msgid "%f will replaced by the text file path."
 msgstr "%f vil blive erstattet af stien til tekstfilen."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Visuel"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -298,10 +320,6 @@ msgid "Increase or decrease the size of this desklet using this scale factor."
 msgstr ""
 "Forøg eller formindsk skrivebordsprogrammets størrelse med denne "
 "skaleringsfaktor."
-
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr "Tilpasset etiket (kun synlig hvis boksen rundt om er aktiveret)"
 
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"

--- a/notes@schorschii/files/notes@schorschii/po/de.po
+++ b/notes@schorschii/files/notes@schorschii/po/de.po
@@ -1,8 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-04 15:06+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2023-04-04 15:06+0200\n"
 "Last-Translator: Georg Sieber\n"
 "Language-Team: \n"
@@ -16,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:130
+#: desklet.js:133
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: desklet.js:143
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -32,7 +33,7 @@ msgstr ""
 "\n"
 "Klicken Sie hier zum Bearbeiten."
 
-#: desklet.js:263
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Notizblock"
 
@@ -41,16 +42,37 @@ msgid "A desklet to display notes including various themes."
 msgstr "Ein Desklet mit verschiedenen Designs um Notizen anzuzeigen."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Notiz"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Einstellungen für notes@schorschii"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Allgemein"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Aussehen"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Textfarbe"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Deskletgröße"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -70,9 +92,9 @@ msgstr "Befehlszeile zum Bearbeiten von Notizen (bei Mausklick)"
 msgid "%f will replaced by the text file path."
 msgstr "%f wird durch den Pfad zur Textdatei ersetzt."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Aussehen"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -270,12 +292,6 @@ msgstr "Schriftgröße"
 msgid "Increase or decrease the note font size."
 msgstr "Erhöhen oder verringern Sie die Schriftgröße der Notiz."
 
-#. settings-schema.json->scale-size->tooltip
-msgid "Increase or decrease the size of this desklet using this scale factor."
-msgstr ""
-"Erhöhen oder verringern Sie die Größe dieses Desklets indem Sie diesen "
-"Skalierungsfaktor anpassen."
-
 #. settings-schema.json->font-bold->description
 msgid "Bold"
 msgstr "Fett"
@@ -300,9 +316,11 @@ msgstr "Skalierungsfaktor"
 msgid "Desklet size"
 msgstr "Deskletgröße"
 
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr "Eigenes Deskletlabel (nur sichtbar wenn Dekorationen aktiviert sind)"
+#. settings-schema.json->scale-size->tooltip
+msgid "Increase or decrease the size of this desklet using this scale factor."
+msgstr ""
+"Erhöhen oder verringern Sie die Größe dieses Desklets indem Sie diesen "
+"Skalierungsfaktor anpassen."
 
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
@@ -325,9 +343,3 @@ msgid ""
 msgstr ""
 "Legen Sie hier Ihr eigenes Deskletlabel fest. Dieses Feld ist deaktiviert, "
 "wenn Sie die Option darüber nicht aktiviert haben."
-
-#~ msgid "Yellow"
-#~ msgstr "Gelb"
-
-#~ msgid "White"
-#~ msgstr "Weiß"

--- a/notes@schorschii/files/notes@schorschii/po/de.po
+++ b/notes@schorschii/files/notes@schorschii/po/de.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2023-04-04 15:06+0200\n"
 "Last-Translator: Georg Sieber\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Klicken Sie hier zum Bearbeiten."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Notizblock"
 

--- a/notes@schorschii/files/notes@schorschii/po/es.po
+++ b/notes@schorschii/files/notes@schorschii/po/es.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# NOTE
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# schorschii, 2018
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2023-11-20 20:52-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -35,7 +35,7 @@ msgstr ""
 "\n"
 "Haga clic aquí para editarlo."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Bloc de notas"
 

--- a/notes@schorschii/files/notes@schorschii/po/fr.po
+++ b/notes@schorschii/files/notes@schorschii/po/fr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2020-01-24 23:40+0100\n"
 "Last-Translator: Anonymous <ano@nymo.us>\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr ""
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Cliquez ici pour modifier."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Bloc Note"
 

--- a/notes@schorschii/files/notes@schorschii/po/fr.po
+++ b/notes@schorschii/files/notes@schorschii/po/fr.po
@@ -1,21 +1,27 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-01-12 18:07+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2020-01-24 23:40+0100\n"
+"Last-Translator: Anonymous <ano@nymo.us>\n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.2.1\n"
 "X-Poedit-Basepath: ..\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Last-Translator: Anonymous <ano@nymo.us>\n"
-"Language: fr\n"
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:109
+#: desklet.js:133
+msgid "Refresh"
+msgstr ""
+
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -27,215 +33,308 @@ msgstr ""
 "\n"
 "Cliquez ici pour modifier."
 
-#: desklet.js:172
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Bloc Note"
 
-msgid "Note"
-msgstr "Note"
-
+#. metadata.json->description
 msgid "A desklet to display notes including various themes."
 msgstr "Un desklet pour afficher des notes aux styles graphiques variés."
 
-msgid "Settings for notes@schorschii"
-msgstr "Paramètres de notes@schorschii"
+#. metadata.json->name
+#. settings-schema.json->note-section->title
+msgid "Note"
+msgstr "Note"
 
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Général"
 
-msgid "Path to note text file"
-msgstr "Chemin vers le fichier de note"
-
-msgid "Select your text file, where to read from and save to."
-msgstr "Sélectionnez un fichier texte dans lequel sera lue et écrite la note."
-
-msgid "Command for editing this note (on mouse click)"
-msgstr "Commande pour éditer cette note (avec un click de souris)"
-
-msgid "%f will replaced by the text file path."
-msgstr "%f sera remplacé par le chemin du fichier."
-
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
 msgid "Visual"
 msgstr "Visuel"
 
-msgid "Select the background graphic you would like to use."
-msgstr "Sélectionnez le fond graphique que vous souhaitez utiliser."
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
 
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Couleur du texte"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Taille de la desklet"
+
+#. settings-schema.json->file->description
+msgid "Path to note text file"
+msgstr "Chemin vers le fichier de note"
+
+#. settings-schema.json->file->tooltip
+msgid "Select your text file, where to read from and save to."
+msgstr "Sélectionnez un fichier texte dans lequel sera lue et écrite la note."
+
+#. settings-schema.json->edit-cmd->description
+msgid "Command for editing this note (on mouse click)"
+msgstr "Commande pour éditer cette note (avec un click de souris)"
+
+#. settings-schema.json->edit-cmd->tooltip
+msgid "%f will replaced by the text file path."
+msgstr "%f sera remplacé par le chemin du fichier."
+
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
+
+#. settings-schema.json->style->description
 msgid "Notes style"
 msgstr "Style des notes"
 
-msgid "Yellow"
-msgstr "Jaune"
-
-msgid "White"
-msgstr "Blanc"
-
+#. settings-schema.json->style->options
 msgid "Blank Note - Black"
 msgstr "Note Vierge - Noir"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Blue"
 msgstr "Note Vierge - Bleu"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Green"
 msgstr "Note Vierge - Vert"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Orange"
 msgstr "Note Vierge - Orange"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Purple"
 msgstr "Note Vierge - Violet"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - White"
 msgstr "Nota Vierge - Blanc"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Yellow"
 msgstr "Note Vierge - Jaune"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Button"
 msgstr "Note Blanche - Punaise Noire"
 
+#. settings-schema.json->style->options
 msgid "White Note - Blue Button"
 msgstr "Note Blanche - Punaise Bleue"
 
+#. settings-schema.json->style->options
 msgid "White Note - Green Button"
 msgstr "Note Blanche - Bouton Vert"
 
+#. settings-schema.json->style->options
 msgid "White Note - Red Button"
 msgstr "Note Blanche - Bouton Rouge"
 
+#. settings-schema.json->style->options
 msgid "White Note - Yellow Button"
 msgstr "Note Blanche - Bouton Jaune"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Black Clip"
 msgstr "Note Jaune - Épingle Noire"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Blue Clip"
 msgstr "Note Jaune - Épingle Bleue"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Green Clip"
 msgstr "Note Jaune - Épingle Verte"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Jingle Clip"
 msgstr "Note Jaune - Épingle Jingle"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Red Clip"
 msgstr "Note Jaune - Épingle Rouge"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Yellow Clip"
 msgstr "Note Jaune - Épingle Jaune"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Magnet"
 msgstr "Note Blanche - Magnet Noir"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Blue Magnet"
 msgstr "Note Blanche - Magnet Bleu"
 
+#. settings-schema.json->style->options
 msgid "White Note - Lines and Red Magnet"
 msgstr "Note Blanche - Magnet Rouge et lignes"
 
+#. settings-schema.json->style->options
 msgid "Black Note - White Magnet"
 msgstr "Note Noire - Magnet Blanc"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Yellow Magnet"
 msgstr "Note Jaune - Magnet Jaune"
 
+#. settings-schema.json->style->options
 msgid "Blue Paint Strokes"
 msgstr "Traces de peinture Bleues"
 
+#. settings-schema.json->style->options
 msgid "Green Paint Strokes"
 msgstr "Traces de peinture Vertes"
 
+#. settings-schema.json->style->options
 msgid "Purple Paint Strokes"
 msgstr "Traces de peinture Violettes"
 
+#. settings-schema.json->style->options
 msgid "Red Paint Strokes"
 msgstr "Traces de peinture Rouges"
 
+#. settings-schema.json->style->options
 msgid "Yellow Paint Strokes"
 msgstr "Traces de peinture Jaunes"
 
+#. settings-schema.json->style->options
 msgid "White Note - Silver Spiral"
 msgstr "Note Blanche - Spirale Argentée"
 
+#. settings-schema.json->style->options
 msgid "White Note - Silver Spiral 2"
 msgstr "Note Blanche - Spirale Argentée 2"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Spiral"
 msgstr "Note Blanche - Spirale Noire"
 
+#. settings-schema.json->style->options
 msgid "White Note Large - Silver Spiral"
 msgstr "Note Blanche Grande - Spirale Argentée"
 
+#. settings-schema.json->style->options
 msgid "Yellow Sticker"
 msgstr "Adhésif Jaune"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note (iOS Style)"
 msgstr "Note Jaune (Style iOS)"
 
+#. settings-schema.json->style->options
 msgid "Birch Bark"
 msgstr "Écorce de Bouleau"
 
+#. settings-schema.json->style->options
 msgid "Burned Paper"
 msgstr "Papier Brûlé"
 
+#. settings-schema.json->style->options
 msgid "Clay Tablet"
 msgstr "Tablette d'argile"
 
+#. settings-schema.json->style->options
 msgid "Coffee Stained"
 msgstr "Teinté de café"
 
+#. settings-schema.json->style->options
 msgid "Clipboard"
 msgstr "Clipboard"
 
+#. settings-schema.json->style->options
+msgid "None"
+msgstr ""
+
+#. settings-schema.json->style->tooltip
+msgid "Select the background graphic you would like to use."
+msgstr "Sélectionnez le fond graphique que vous souhaitez utiliser."
+
+#. settings-schema.json->bg-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->bg-color->tooltip
+#, fuzzy
+msgid "Set the background color of this desklet."
+msgstr "Changer la couleur du texte de ce desklet."
+
+#. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"
 msgstr "Masquer les décorations"
 
+#. settings-schema.json->font->description
 msgid "Font"
 msgstr "Police"
 
-msgid "Bold"
-msgstr "Gras"
-
-msgid "Italic"
-msgstr "Italique"
-
-msgid "Font size"
-msgstr "Taille de police"
-
-msgid "Increase or decrease the size of this desklet using this scale factor."
-msgstr "Augmenter ou réduire la taille de cette desklet selon cette échelle."
-
-msgid "Set the text color of this desklet."
-msgstr "Changer la couleur du texte de ce desklet."
-
-msgid "Text color"
-msgstr "Couleur du texte"
-
-msgid "Desklet size"
-msgstr "Taille de la desklet"
-
+#. settings-schema.json->size-font->units
 msgid "pixels"
 msgstr "pixels"
 
+#. settings-schema.json->size-font->description
+msgid "Font size"
+msgstr "Taille de police"
+
+#. settings-schema.json->size-font->tooltip
+#, fuzzy
+msgid "Increase or decrease the note font size."
+msgstr "Augmenter ou réduire la taille de cette desklet selon cette échelle."
+
+#. settings-schema.json->font-bold->description
+msgid "Bold"
+msgstr "Gras"
+
+#. settings-schema.json->font-italic->description
+msgid "Italic"
+msgstr "Italique"
+
+#. settings-schema.json->text-color->description
+msgid "Text color"
+msgstr "Couleur du texte"
+
+#. settings-schema.json->text-color->tooltip
+msgid "Set the text color of this desklet."
+msgstr "Changer la couleur du texte de ce desklet."
+
+#. settings-schema.json->scale-size->units
 msgid "scale factor"
 msgstr "facteur d'échelle"
 
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Étiquette de desklet personnalisée (visible seulement si décorations "
-"activées)" 
+#. settings-schema.json->scale-size->description
+msgid "Desklet size"
+msgstr "Taille de la desklet"
 
+#. settings-schema.json->scale-size->tooltip
+msgid "Increase or decrease the size of this desklet using this scale factor."
+msgstr "Augmenter ou réduire la taille de cette desklet selon cette échelle."
+
+#. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
 msgstr "Utiliser une étiquette de desklet personnalisée"
 
+#. settings-schema.json->use-custom-label->tooltip
 msgid "Checking this box allows you to set a custom label in the field below."
 msgstr ""
-"Cocher cette case vous permet de changer l'étiquette personnalisée "
-"du champ ci-dessous."
+"Cocher cette case vous permet de changer l'étiquette personnalisée du champ "
+"ci-dessous."
 
+#. settings-schema.json->custom-label->description
 msgid "Custom desklet label"
 msgstr "Etiquette de desklet personnalisée"
 
+#. settings-schema.json->custom-label->tooltip
 msgid ""
 "Set your custom label here. This field is unavailable unless the checkbox "
 "above is enabled."

--- a/notes@schorschii/files/notes@schorschii/po/hu.po
+++ b/notes@schorschii/files/notes@schorschii/po/hu.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-04 15:06+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2023-05-06 06:59+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -17,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: desklet.js:130
+#: desklet.js:133
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: desklet.js:143
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +34,7 @@ msgstr ""
 "\n"
 "Kattintson ide a szerkesztéshez."
 
-#: desklet.js:263
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Jegyzettömb"
 
@@ -42,16 +43,37 @@ msgid "A desklet to display notes including various themes."
 msgstr "Jegyzetek megjelenítésére szolgáló asztalkalmazás különféle témákkal."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Jegyzet"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Notes@schorschii beállításai"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Általános"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Vizuális"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Szövegszín"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Asztalkalmazás mérete"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -69,9 +91,9 @@ msgstr "A jegyzet szerkesztéséhez használt parancs (egérkattintásra)"
 msgid "%f will replaced by the text file path."
 msgstr "%f a szöveges fájl elérési útvonalára lesz cserélve."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Vizuális"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -297,11 +319,6 @@ msgstr "Asztalkalmazás mérete"
 msgid "Increase or decrease the size of this desklet using this scale factor."
 msgstr ""
 "Növelje vagy csökkentse az asztalkalmazás méretét a skála segítéségével."
-
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Egyéni asztali címke (csak akkor látható, ha a dekoráció engedélyezve van)"
 
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"

--- a/notes@schorschii/files/notes@schorschii/po/hu.po
+++ b/notes@schorschii/files/notes@schorschii/po/hu.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# NOTE
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# schorschii, 2018
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2023-05-06 06:59+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -34,7 +34,7 @@ msgstr ""
 "\n"
 "Kattintson ide a szerkesztéshez."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Jegyzettömb"
 

--- a/notes@schorschii/files/notes@schorschii/po/it.po
+++ b/notes@schorschii/files/notes@schorschii/po/it.po
@@ -1,8 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-04 15:06+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2023-12-12 18:46+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -16,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:130
+#: desklet.js:133
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: desklet.js:143
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -32,7 +33,7 @@ msgstr ""
 "\n"
 "Clicca qui per modificare."
 
-#: desklet.js:263
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Blocco note"
 
@@ -41,16 +42,37 @@ msgid "A desklet to display notes including various themes."
 msgstr "Un desklet per mostrare note includendo vari temi."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Nota"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Impostazioni di notes@schorschii"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Generale"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Visuale"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Colore del testo"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Dimensioni desklet"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -68,9 +90,9 @@ msgstr "Comando per modificare questa nota (al clic del mouse)"
 msgid "%f will replaced by the text file path."
 msgstr "%f verrà sostituito dal percorso del file di testo."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Visuale"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -298,12 +320,6 @@ msgstr ""
 "Aumenta o riduci le dimensioni di questo desklet utilizzando questo fattore "
 "di scala."
 
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Etichetta del desklet personalizzata (visibile solo se le decorazioni sono "
-"abilitate)"
-
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
 msgstr "Utilizzare un'etichetta desklet personalizzata"
@@ -325,9 +341,3 @@ msgid ""
 msgstr ""
 "Imposta qui la tua etichetta personalizzata. Questo campo non è disponibile "
 "a meno che la casella sopra non sia abilitata."
-
-#~ msgid "Yellow"
-#~ msgstr "Giallo"
-
-#~ msgid "White"
-#~ msgstr "Bianco"

--- a/notes@schorschii/files/notes@schorschii/po/it.po
+++ b/notes@schorschii/files/notes@schorschii/po/it.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2023-12-12 18:46+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Clicca qui per modificare."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Blocco note"
 

--- a/notes@schorschii/files/notes@schorschii/po/nl.po
+++ b/notes@schorschii/files/notes@schorschii/po/nl.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-04 15:06+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2024-04-19 13:05+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: desklet.js:130
+#: desklet.js:133
 msgid "Refresh"
 msgstr "Vernieuwen"
 
-#: desklet.js:143
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -32,7 +33,7 @@ msgstr ""
 " \n"
 "Klik hier om te bewerken."
 
-#: desklet.js:263
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Kladblok"
 
@@ -41,16 +42,37 @@ msgid "A desklet to display notes including various themes."
 msgstr "Een desklet om notities weer te geven inclusief verschillende thema's."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Notitie"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Instellingen voor notes@schorschii"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Algemeen"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Visueel"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Tekstkleur"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Grootte van de desklet"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -70,9 +92,9 @@ msgstr "Commando voor het bewerken van deze notitie (bij muisklik)"
 msgid "%f will replaced by the text file path."
 msgstr "%f wordt vervangen door het pad naar het tekstbestand."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Visueel"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -299,11 +321,6 @@ msgid "Increase or decrease the size of this desklet using this scale factor."
 msgstr ""
 "Vergroot of verklein de grootte van deze desklet met behulp van deze "
 "schaalfactor."
-
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Aangepast deskletlabel (alleen zichtbaar als decoraties zijn ingeschakeld)"
 
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"

--- a/notes@schorschii/files/notes@schorschii/po/nl.po
+++ b/notes@schorschii/files/notes@schorschii/po/nl.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# NOTE
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# schorschii, 2018
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2024-04-19 13:05+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Vernieuwen"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 " \n"
 "Klik hier om te bewerken."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Kladblok"
 

--- a/notes@schorschii/files/notes@schorschii/po/notes@schorschii.pot
+++ b/notes@schorschii/files/notes@schorschii/po/notes@schorschii.pot
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
+# NOTE
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# schorschii, 2018
 #
 #, fuzzy
 msgid ""
@@ -8,20 +8,20 @@ msgstr ""
 "Project-Id-Version: notes@schorschii 2.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr ""
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -29,7 +29,7 @@ msgid ""
 "Click here to edit."
 msgstr ""
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr ""
 

--- a/notes@schorschii/files/notes@schorschii/po/notes@schorschii.pot
+++ b/notes@schorschii/files/notes@schorschii/po/notes@schorschii.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is put in the public domain.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-04 15:06+0200\n"
+"Project-Id-Version: notes@schorschii 2.4\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: desklet.js:130
+#: desklet.js:133
 msgid "Refresh"
 msgstr ""
 
-#: desklet.js:143
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -29,7 +29,7 @@ msgid ""
 "Click here to edit."
 msgstr ""
 
-#: desklet.js:263
+#: desklet.js:272
 msgid "Notepad"
 msgstr ""
 
@@ -38,15 +38,34 @@ msgid "A desklet to display notes including various themes."
 msgstr ""
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr ""
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
+msgid "General"
 msgstr ""
 
-#. settings-schema.json->head1->description
-msgid "General"
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr ""
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+msgid "Text File"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+msgid "Desklet Settings"
 msgstr ""
 
 #. settings-schema.json->file->description
@@ -65,8 +84,8 @@ msgstr ""
 msgid "%f will replaced by the text file path."
 msgstr ""
 
-#. settings-schema.json->head2->description
-msgid "Visual"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
 msgstr ""
 
 #. settings-schema.json->style->description
@@ -291,10 +310,6 @@ msgstr ""
 
 #. settings-schema.json->scale-size->tooltip
 msgid "Increase or decrease the size of this desklet using this scale factor."
-msgstr ""
-
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
 
 #. settings-schema.json->use-custom-label->description

--- a/notes@schorschii/files/notes@schorschii/po/pt.po
+++ b/notes@schorschii/files/notes@schorschii/po/pt.po
@@ -1,27 +1,26 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is put in the public domain.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: notes@schorschii 2.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
 "POT-Creation-Date: 2024-09-28 15:16-0100\n"
-"PO-Revision-Date: 2023-11-20 20:52-0300\n"
+"PO-Revision-Date: 2024-09-28 15:39-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #: desklet.js:133
 msgid "Refresh"
-msgstr "Actualizar"
+msgstr "Atualizar"
 
 #: desklet.js:146
 msgid ""
@@ -30,18 +29,18 @@ msgid ""
 "\n"
 "Click here to edit."
 msgstr ""
-"No se puede leer el archivo de texto.\n"
-"Seleccione un archivo en la configuración.\n"
+"Ficheiro não pode ser lido\n"
+"Selecione um ficheiro nas definições\n"
 "\n"
-"Haga clic aquí para editarlo."
+"Clique aqui para editar."
 
 #: desklet.js:272
 msgid "Notepad"
-msgstr "Bloc de notas"
+msgstr "Bloco de notas"
 
 #. metadata.json->description
 msgid "A desklet to display notes including various themes."
-msgstr "Un desklet para mostrar notas que incluyen varios temas."
+msgstr "Um desklet que mostra notas incluindo diversos temas."
 
 #. metadata.json->name
 #. settings-schema.json->note-section->title
@@ -51,7 +50,7 @@ msgstr "Nota"
 #. settings-schema.json->general-page->title
 #. settings-schema.json->general-section->title
 msgid "General"
-msgstr "General"
+msgstr "Geral"
 
 #. settings-schema.json->visual-page->title
 #. settings-schema.json->visual-section->title
@@ -60,285 +59,283 @@ msgstr "Visual"
 
 #. settings-schema.json->label-section->title
 msgid "Label"
-msgstr ""
+msgstr "Etiqueta"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"
-msgstr ""
+msgstr "Método de Anotação"
 
 #. settings-schema.json->note-taking-method->options
-#, fuzzy
 msgid "Text File"
-msgstr "Color del texto"
+msgstr "Ficheiro de Texto"
 
 #. settings-schema.json->note-taking-method->options
-#, fuzzy
 msgid "Desklet Settings"
-msgstr "Tamaño del desklet"
+msgstr "Definições do Desktlet"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
-msgstr "Ruta de acceso al archivo de texto de la nota"
+msgstr "Caminho para o ficheiro de texto da nota"
 
 #. settings-schema.json->file->tooltip
 msgid "Select your text file, where to read from and save to."
-msgstr "Seleccione su archivo de texto, desde donde leer y guardar."
+msgstr "Selecione o seu ficheiro de texto, para ler a partir de e guardar em."
 
 #. settings-schema.json->edit-cmd->description
 msgid "Command for editing this note (on mouse click)"
-msgstr "Comando para editar esta nota (al hacer clic con el ratón)"
+msgstr "Comando para editar a sua nota (ao clicar no desklet)"
 
 #. settings-schema.json->edit-cmd->tooltip
 msgid "%f will replaced by the text file path."
-msgstr "%f será reemplazado por la ruta del archivo de texto."
+msgstr "%f será trocado pelo caminho do ficheiro de texto."
 
 #. settings-schema.json->note-text->description
 msgid "Write Your Note"
-msgstr ""
+msgstr "Escreva a Sua nota"
 
 #. settings-schema.json->style->description
 msgid "Notes style"
-msgstr "Estilo de notas"
+msgstr "Estilo da Nota"
 
 #. settings-schema.json->style->options
 msgid "Blank Note - Black"
-msgstr "Nota en blanco - Negra"
+msgstr "Nota em Branco - Preta"
 
 #. settings-schema.json->style->options
 msgid "Blank Note - Blue"
-msgstr "Nota en blanco - Azul"
+msgstr "Nota em Branco - Azul"
 
 #. settings-schema.json->style->options
 msgid "Blank Note - Green"
-msgstr "Nota en blanco - Verde"
+msgstr "Nota em Branco - Verde"
 
 #. settings-schema.json->style->options
 msgid "Blank Note - Orange"
-msgstr "Nota en blanco - Naranja"
+msgstr "Nota em Branco - Laranja"
 
 #. settings-schema.json->style->options
 msgid "Blank Note - Purple"
-msgstr "Nota en blanco - Púrpura"
+msgstr "Nota em Branco - Roxa"
 
 #. settings-schema.json->style->options
 msgid "Blank Note - White"
-msgstr "Nota en blanco - Blanca"
+msgstr "Nota em Branco - Branca"
 
 #. settings-schema.json->style->options
 msgid "Blank Note - Yellow"
-msgstr "Nota en blanco - Amarilla"
+msgstr "Nota em Branco - Amarela"
 
 #. settings-schema.json->style->options
 msgid "White Note - Black Button"
-msgstr "Nota blanca - Tachuela negra"
+msgstr "Nota Branca - Botão Preto"
 
 #. settings-schema.json->style->options
 msgid "White Note - Blue Button"
-msgstr "Nota blanca - Tachuela azul"
+msgstr "Nota Branca - Botão Azul"
 
 #. settings-schema.json->style->options
 msgid "White Note - Green Button"
-msgstr "Nota blanca - Tachuela verde"
+msgstr "Nota Branca - Botão Verde"
 
 #. settings-schema.json->style->options
 msgid "White Note - Red Button"
-msgstr "Nota blanca - Tachuela roja"
+msgstr "Nota Branca - Botão Vermelho"
 
 #. settings-schema.json->style->options
 msgid "White Note - Yellow Button"
-msgstr "Nota blanca - Tachuela amarilla"
+msgstr "Nota Branca - Botão Amarelo"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note - Black Clip"
-msgstr "Nota amarilla - Clip negro"
+msgstr "Nota Amarela - Clipe Preto"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note - Blue Clip"
-msgstr "Nota amarilla - Clip azul"
+msgstr "Nota Amarela - Clipe Azul"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note - Green Clip"
-msgstr "Nota amarilla - Clip verde"
+msgstr "Nota Amarela - Clipe Verde"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note - Jingle Clip"
-msgstr "Nota amarilla - Clip navideño"
+msgstr "Nota Amarela - Clipe Jingle"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note - Red Clip"
-msgstr "Nota amarilla - Clip rojo"
+msgstr "Nota Amarela - Clipe Vermelho"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note - Yellow Clip"
-msgstr "Nota amarilla - Clip amarillo"
+msgstr "Nota Amarela - Clipe Amarelo"
 
 #. settings-schema.json->style->options
 msgid "White Note - Black Magnet"
-msgstr "Nota blanca - Imán negro"
+msgstr "Nota Branca - Ímã Preto"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note - Blue Magnet"
-msgstr "Nota amarilla - Imán azul"
+msgstr "Nota Amarela - Ímã Azul"
 
 #. settings-schema.json->style->options
 msgid "White Note - Lines and Red Magnet"
-msgstr "Nota blanca - Imán y líneas rojas"
+msgstr "Nota Branca - Ímã Preto e Linhas"
 
 #. settings-schema.json->style->options
 msgid "Black Note - White Magnet"
-msgstr "Nota negra - Imán blanco"
+msgstr "Nota Preta - Ímã Branco"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note - Yellow Magnet"
-msgstr "Nota amarilla - Imán amarillo"
+msgstr "Nota Amarela - Ímã Amarelo"
 
 #. settings-schema.json->style->options
 msgid "Blue Paint Strokes"
-msgstr "Pinceladas de pintura azul"
+msgstr "Traços de Tinta Azul"
 
 #. settings-schema.json->style->options
 msgid "Green Paint Strokes"
-msgstr "Pinceladas de pintura verde"
+msgstr "Traços de Tinta Verde"
 
 #. settings-schema.json->style->options
 msgid "Purple Paint Strokes"
-msgstr "Pinceladas de pintura púrpura"
+msgstr "Traços de Tinta Roxa"
 
 #. settings-schema.json->style->options
 msgid "Red Paint Strokes"
-msgstr "Pinceladas de pintura roja"
+msgstr "Traços de Tinta Vermelha"
 
 #. settings-schema.json->style->options
 msgid "Yellow Paint Strokes"
-msgstr "Pinceladas de pintura amarilla"
+msgstr "Traços de Tinta Amarela"
 
 #. settings-schema.json->style->options
 msgid "White Note - Silver Spiral"
-msgstr "Nota blanca - Espiral plateado"
+msgstr "Nota Branca - Espiral Prata"
 
 #. settings-schema.json->style->options
 msgid "White Note - Silver Spiral 2"
-msgstr "Nota blanca - Espiral plateado 2"
+msgstr "Nota Branca - Espiral Prata 2"
 
 #. settings-schema.json->style->options
 msgid "White Note - Black Spiral"
-msgstr "Nota blanca - Espiral negro"
+msgstr "Nota Branca - Espiral Preta"
 
 #. settings-schema.json->style->options
 msgid "White Note Large - Silver Spiral"
-msgstr "Nota blanca grande - Espiral plateado"
+msgstr "Nota Branca Larga - Espiral Prata"
 
 #. settings-schema.json->style->options
 msgid "Yellow Sticker"
-msgstr "Pegatina amarilla"
+msgstr "Adesivo Amarelo"
 
 #. settings-schema.json->style->options
 msgid "Yellow Note (iOS Style)"
-msgstr "Nota amarilla (estilo iOS)"
+msgstr "Adesivo Amarelo (Estilo IOS)"
 
 #. settings-schema.json->style->options
 msgid "Birch Bark"
-msgstr "Corteza de abedul"
+msgstr "Casca de Bétula"
 
 #. settings-schema.json->style->options
 msgid "Burned Paper"
-msgstr "Papel quemado"
+msgstr "Papel Queimado"
 
 #. settings-schema.json->style->options
 msgid "Clay Tablet"
-msgstr "Tabla de arcilla"
+msgstr "Tábua de Argila"
 
 #. settings-schema.json->style->options
 msgid "Coffee Stained"
-msgstr "Manchas de café"
+msgstr "Mancha de Café"
 
 #. settings-schema.json->style->options
 msgid "Clipboard"
-msgstr "Portapapeles"
+msgstr "Prancheta"
 
 #. settings-schema.json->style->options
 msgid "None"
-msgstr "Ninguna"
+msgstr "Nenhum"
 
 #. settings-schema.json->style->tooltip
 msgid "Select the background graphic you would like to use."
-msgstr "Seleccione el gráfico de fondo que desea utilizar."
+msgstr "Selecione o gráfico de fundo que gostaria de utilizar."
 
 #. settings-schema.json->bg-color->description
 msgid "Background color"
-msgstr "Color de fondo"
+msgstr "Cor de fundo"
 
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
-msgstr "Establece el color de fondo de este desklet."
+msgstr "Defina a cor de fundo deste desklet."
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"
-msgstr "Ocultar decoraciones"
+msgstr "Esconder decorações"
 
 #. settings-schema.json->font->description
 msgid "Font"
-msgstr "Fuente"
+msgstr "Fonte"
 
 #. settings-schema.json->size-font->units
 msgid "pixels"
-msgstr "píxeles"
+msgstr "pixeis"
 
 #. settings-schema.json->size-font->description
 msgid "Font size"
-msgstr "Tamaño de letra"
+msgstr "Tamanho da fonte"
 
 #. settings-schema.json->size-font->tooltip
 msgid "Increase or decrease the note font size."
-msgstr "Aumentar o disminuir el tamaño de la letra de la nota."
+msgstr "Aumente ou diminua o tamanho da fonte da nota."
 
 #. settings-schema.json->font-bold->description
 msgid "Bold"
-msgstr "Negrita"
+msgstr "Negrito"
 
 #. settings-schema.json->font-italic->description
 msgid "Italic"
-msgstr "Cursiva"
+msgstr "Itálico"
 
 #. settings-schema.json->text-color->description
 msgid "Text color"
-msgstr "Color del texto"
+msgstr "Cor do texto"
 
 #. settings-schema.json->text-color->tooltip
 msgid "Set the text color of this desklet."
-msgstr "Establecer el color del texto de este desklet."
+msgstr "Defina a cor do texto deste desklet."
 
 #. settings-schema.json->scale-size->units
 msgid "scale factor"
-msgstr "factor de escala"
+msgstr "escala"
 
 #. settings-schema.json->scale-size->description
 msgid "Desklet size"
-msgstr "Tamaño del desklet"
+msgstr "Tamanho do desklet"
 
 #. settings-schema.json->scale-size->tooltip
 msgid "Increase or decrease the size of this desklet using this scale factor."
 msgstr ""
-"Aumente o disminuya el tamaño de este desklet usando este factor de escala."
+"Aumente ou diminua o tamanho deste desklet utilizando este fator de escala."
 
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
-msgstr "Utilice una etiqueta personalizada del desklet"
+msgstr "Use uma etiqueta personalizada"
 
 #. settings-schema.json->use-custom-label->tooltip
 msgid "Checking this box allows you to set a custom label in the field below."
 msgstr ""
-"Marcar esta casilla permite establecer una etiqueta personalizada en el "
-"campo a continuación."
+"A marcação desta caixa permite definir um rótulo personalizado no campo "
+"abaixo."
 
 #. settings-schema.json->custom-label->description
 msgid "Custom desklet label"
-msgstr "Etiqueta personalizada del desklet"
+msgstr "Etiqueta personalizada do desklet"
 
 #. settings-schema.json->custom-label->tooltip
 msgid ""
 "Set your custom label here. This field is unavailable unless the checkbox "
 "above is enabled."
 msgstr ""
-"Configure su etiqueta personalizada aquí. Este campo no está disponible a "
-"menos que la casilla anterior esté habilitada."
+"Defina aqui a sua etiqueta personalizada. Este campo não estará disponível "
+"a menos que a caixa de seleção acima esteja ativada."

--- a/notes@schorschii/files/notes@schorschii/po/pt.po
+++ b/notes@schorschii/files/notes@schorschii/po/pt.po
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
+# NOTE
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# schorschii, 2018
 #
 #, fuzzy
 msgid ""
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: notes@schorschii 2.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2024-09-28 15:39-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -34,7 +34,7 @@ msgstr ""
 "\n"
 "Clique aqui para editar."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Bloco de notas"
 
@@ -337,5 +337,5 @@ msgid ""
 "Set your custom label here. This field is unavailable unless the checkbox "
 "above is enabled."
 msgstr ""
-"Defina aqui a sua etiqueta personalizada. Este campo não estará disponível "
-"a menos que a caixa de seleção acima esteja ativada."
+"Defina aqui a sua etiqueta personalizada. Este campo não estará disponível a "
+"menos que a caixa de seleção acima esteja ativada."

--- a/notes@schorschii/files/notes@schorschii/po/pt_BR.po
+++ b/notes@schorschii/files/notes@schorschii/po/pt_BR.po
@@ -6,19 +6,24 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-14 14:37+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2021-09-28 22:12-0300\n"
+"Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: Marcelo Aof\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: pt_BR\n"
 
-#: desklet.js:137
+#: desklet.js:133
+msgid "Refresh"
+msgstr ""
+
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -30,7 +35,7 @@ msgstr ""
 "\n"
 "Clique aqui para editar."
 
-#: desklet.js:229
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Bloco de notas"
 
@@ -40,16 +45,37 @@ msgstr ""
 "Um desklet que exibe anotações em uma grande variedade visual de notas."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Anotação"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Configurações de notes@schorschii"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Visão geral"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Visual"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Cor do texto"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Tamanho do desklet"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -68,9 +94,9 @@ msgstr "Comando para editar essa anotação (com um clique do mouse)"
 msgid "%f will replaced by the text file path."
 msgstr "%f se refere ao endereço do arquivo de texto."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Visual"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -240,6 +266,15 @@ msgstr "Nenhum"
 msgid "Select the background graphic you would like to use."
 msgstr "Selecione a cor da anotação de sua preferência."
 
+#. settings-schema.json->bg-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->bg-color->tooltip
+#, fuzzy
+msgid "Set the background color of this desklet."
+msgstr "Defina a cor do texto desse desklet."
+
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"
 msgstr "Esconder decorações do sistema"
@@ -259,11 +294,6 @@ msgstr "Tamanho da fonte"
 #. settings-schema.json->size-font->tooltip
 msgid "Increase or decrease the note font size."
 msgstr "Aumente ou diminua o tamanho da fonte da anotação."
-
-#. settings-schema.json->scale-size->tooltip
-msgid "Increase or decrease the size of this desklet using this scale factor."
-msgstr ""
-"Aumente ou diminua o tamanho desse desklet usando esta escala de proporção."
 
 #. settings-schema.json->font-bold->description
 msgid "Bold"
@@ -289,11 +319,10 @@ msgstr "escala de proporção"
 msgid "Desklet size"
 msgstr "Tamanho do desklet"
 
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
+#. settings-schema.json->scale-size->tooltip
+msgid "Increase or decrease the size of this desklet using this scale factor."
 msgstr ""
-"Rótulo personalizado do desklet (visível apenas se as decorações não "
-"estiverem escondidas)"
+"Aumente ou diminua o tamanho desse desklet usando esta escala de proporção."
 
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
@@ -314,5 +343,5 @@ msgid ""
 "Set your custom label here. This field is unavailable unless the checkbox "
 "above is enabled."
 msgstr ""
-"Digite o seu rótulo personalizado aqui. Essa opção tem efeito quando a "
-"caixa de seleção acima estiver ativada."
+"Digite o seu rótulo personalizado aqui. Essa opção tem efeito quando a caixa "
+"de seleção acima estiver ativada."

--- a/notes@schorschii/files/notes@schorschii/po/pt_BR.po
+++ b/notes@schorschii/files/notes@schorschii/po/pt_BR.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# NOTE
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Marcelo Aof, 2021.
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2021-09-28 22:12-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr ""
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -35,7 +35,7 @@ msgstr ""
 "\n"
 "Clique aqui para editar."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Bloco de notas"
 

--- a/notes@schorschii/files/notes@schorschii/po/ro.po
+++ b/notes@schorschii/files/notes@schorschii/po/ro.po
@@ -5,23 +5,25 @@
 #
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: ro\n"
-"Language-Team: none\n"
-"Last-Translator: Automatically generated\n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2023-04-04 15:06+0200\n"
-"POT-Creation-Date: 2023-04-04 15:06+0200\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"PO-Revision-Date: 2023-04-04 15:06+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
 
-#: desklet.js:130
+#: desklet.js:133
 msgid "Refresh"
 msgstr "Reîmprospătare"
 
-#: desklet.js:143
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +35,7 @@ msgstr ""
 "\n"
 "Fă clic aici pentru a edita."
 
-#: desklet.js:263
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Blocul de notițe"
 
@@ -42,16 +44,37 @@ msgid "A desklet to display notes including various themes."
 msgstr "Un desklet pentru afișarea notelor, cu diverse teme."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Notă"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Setări pentru notes@schorschii"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "General"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Vizual"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Culoarea textului"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Dimensiune Desklet"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -69,9 +92,9 @@ msgstr "Comandă pentru editarea acestei note (la un clic de mouse)"
 msgid "%f will replaced by the text file path."
 msgstr "%f va fi înlocuit cu calea fișierului text."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Vizual"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -295,11 +318,9 @@ msgstr "Dimensiune Desklet"
 
 #. settings-schema.json->scale-size->tooltip
 msgid "Increase or decrease the size of this desklet using this scale factor."
-msgstr "Mărește sau micșorează dimensiunea acestui desklet folosind acest factor de scară."
-
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr "Etichetă personalizată pentru desklet (vizibilă numai dacă sunt activate decorațiile)"
+msgstr ""
+"Mărește sau micșorează dimensiunea acestui desklet folosind acest factor de "
+"scară."
 
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
@@ -307,12 +328,18 @@ msgstr "Folosește o etichetă personalizată pentru desklet"
 
 #. settings-schema.json->use-custom-label->tooltip
 msgid "Checking this box allows you to set a custom label in the field below."
-msgstr "Dacă bifezi această casetă, poți seta o etichetă personalizată în câmpul de mai jos."
+msgstr ""
+"Dacă bifezi această casetă, poți seta o etichetă personalizată în câmpul de "
+"mai jos."
 
 #. settings-schema.json->custom-label->description
 msgid "Custom desklet label"
 msgstr "Etichetă personalizată de birou"
 
 #. settings-schema.json->custom-label->tooltip
-msgid "Set your custom label here. This field is unavailable unless the checkbox above is enabled."
-msgstr "Setează aici eticheta personalizată. Acest câmp nu este disponibil decât dacă caseta de selectare de mai sus este activată."
+msgid ""
+"Set your custom label here. This field is unavailable unless the checkbox "
+"above is enabled."
+msgstr ""
+"Setează aici eticheta personalizată. Acest câmp nu este disponibil decât "
+"dacă caseta de selectare de mai sus este activată."

--- a/notes@schorschii/files/notes@schorschii/po/ro.po
+++ b/notes@schorschii/files/notes@schorschii/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2023-04-04 15:06+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
 "20)) ? 1 : 2;\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr "Reîmprospătare"
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -35,7 +35,7 @@ msgstr ""
 "\n"
 "Fă clic aici pentru a edita."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Blocul de notițe"
 

--- a/notes@schorschii/files/notes@schorschii/po/ru.po
+++ b/notes@schorschii/files/notes@schorschii/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2021-03-14 14:38+0100\n"
 "Last-Translator: Alex Savvin <savvin@mail.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr ""
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -34,7 +34,7 @@ msgstr ""
 "\n"
 "Щёлкните здесь для редактирования."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Блокнот"
 

--- a/notes@schorschii/files/notes@schorschii/po/ru.po
+++ b/notes@schorschii/files/notes@schorschii/po/ru.po
@@ -2,8 +2,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-14 14:37+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2021-03-14 14:38+0100\n"
 "Last-Translator: Alex Savvin <savvin@mail.ru>\n"
 "Language-Team: \n"
@@ -17,7 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:137
+#: desklet.js:133
+msgid "Refresh"
+msgstr ""
+
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -29,7 +34,7 @@ msgstr ""
 "\n"
 "Щёлкните здесь для редактирования."
 
-#: desklet.js:229
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Блокнот"
 
@@ -38,16 +43,37 @@ msgid "A desklet to display notes including various themes."
 msgstr "Десклет показа заметок, имеющий множество тем."
 
 #. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Заметка"
 
-#. settings-schema.json->head0->description
-msgid "Settings for notes@schorschii"
-msgstr "Настройки notes@schorschii"
-
-#. settings-schema.json->head1->description
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Общие"
+
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
+msgid "Visual"
+msgstr "Отображение"
+
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Цвет текста"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Размер дисклета"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"
@@ -65,9 +91,9 @@ msgstr "Команда для редактирования этой заметк
 msgid "%f will replaced by the text file path."
 msgstr "%f заменится на путь к текстовому файлу."
 
-#. settings-schema.json->head2->description
-msgid "Visual"
-msgstr "Отображение"
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
 
 #. settings-schema.json->style->description
 msgid "Notes style"
@@ -237,6 +263,15 @@ msgstr "–"
 msgid "Select the background graphic you would like to use."
 msgstr "Выберите желаемый фон."
 
+#. settings-schema.json->bg-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->bg-color->tooltip
+#, fuzzy
+msgid "Set the background color of this desklet."
+msgstr "Настройка цвета текста дисклета."
+
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"
 msgstr "Скрыть декорации"
@@ -254,8 +289,8 @@ msgid "Font size"
 msgstr "Размер шрифта"
 
 #. settings-schema.json->size-font->tooltip
-#. settings-schema.json->scale-size->tooltip
-msgid "Increase or decrease the size of this desklet using this scale factor."
+#, fuzzy
+msgid "Increase or decrease the note font size."
 msgstr ""
 "Коэффициент масштабирования - увеличение или уменьшение размера дисклета."
 
@@ -283,9 +318,10 @@ msgstr "масштаб"
 msgid "Desklet size"
 msgstr "Размер дисклета"
 
-#. settings-schema.json->head3->description
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr "Настройка названия десклета (только при включенных декорациях)"
+#. settings-schema.json->scale-size->tooltip
+msgid "Increase or decrease the size of this desklet using this scale factor."
+msgstr ""
+"Коэффициент масштабирования - увеличение или уменьшение размера дисклета."
 
 #. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
@@ -306,9 +342,3 @@ msgid ""
 msgstr ""
 "Задайте своё название десклета. Это поле недоступно, если не установлена "
 "галочка выше."
-
-#~ msgid "Yellow"
-#~ msgstr "Жёлтый"
-
-#~ msgid "White"
-#~ msgstr "Белый"

--- a/notes@schorschii/files/notes@schorschii/po/sv.po
+++ b/notes@schorschii/files/notes@schorschii/po/sv.po
@@ -6,21 +6,27 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: notes@schorschii\n"
-"POT-Creation-Date: 2018-01-12 18:07+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2019-02-27 06:19+0100\n"
+"Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: ..\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
-"Language: sv\n"
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:109
+#: desklet.js:133
+msgid "Refresh"
+msgstr ""
+
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -32,215 +38,310 @@ msgstr ""
 "\n"
 "Klicka här för att redigera."
 
-#: desklet.js:172
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Notepad"
 
+#. metadata.json->description
+msgid "A desklet to display notes including various themes."
+msgstr "Ett skrivbordsprogram för att visa anteckningar, med varierande teman."
+
+#. metadata.json->name
+#. settings-schema.json->note-section->title
 msgid "Note"
 msgstr "Note"
 
-msgid "A desklet to display notes including various themes."
-msgstr ""
-"Ett skrivbordsprogram för att visa anteckningar, med varierande teman."
-
-msgid "Settings for notes@schorschii"
-msgstr "Inställningar för notes@schorschii"
-
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Allmänt"
 
-msgid "Path to note text file"
-msgstr "Sökväg till anteckningsfil"
-
-msgid "Select your text file, where to read from and save to."
-msgstr "Välj den textfil, som skall läsas från och sparas till."
-
-msgid "Command for editing this note (on mouse click)"
-msgstr "Kommando för att redigera denna anteckning (vid musklick)"
-
-msgid "%f will replaced by the text file path."
-msgstr "%f ersätts av sökvägen till din textfil."
-
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
 msgid "Visual"
 msgstr "Visuellt"
 
-msgid "Select the background graphic you would like to use."
-msgstr "Välj den bakgrundsgrafik du vill använda."
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
 
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Textfärg"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Programstorlek"
+
+#. settings-schema.json->file->description
+msgid "Path to note text file"
+msgstr "Sökväg till anteckningsfil"
+
+#. settings-schema.json->file->tooltip
+msgid "Select your text file, where to read from and save to."
+msgstr "Välj den textfil, som skall läsas från och sparas till."
+
+#. settings-schema.json->edit-cmd->description
+msgid "Command for editing this note (on mouse click)"
+msgstr "Kommando för att redigera denna anteckning (vid musklick)"
+
+#. settings-schema.json->edit-cmd->tooltip
+msgid "%f will replaced by the text file path."
+msgstr "%f ersätts av sökvägen till din textfil."
+
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
+
+#. settings-schema.json->style->description
 msgid "Notes style"
 msgstr "Anteckningsstil"
 
-msgid "Yellow"
-msgstr "Gul"
-
-msgid "White"
-msgstr "Vit"
-
+#. settings-schema.json->style->options
 msgid "Blank Note - Black"
 msgstr "Slätt ark - Svart"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Blue"
 msgstr "Slätt ark - Blå"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Green"
 msgstr "Slätt ark - Grön"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Orange"
 msgstr "Slätt ark - Orange"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Purple"
 msgstr "Slätt ark - Lila"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - White"
 msgstr "Slätt ark - Vit"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Yellow"
 msgstr "Slätt ark - Gul"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Button"
 msgstr "Vitt ark - Svart nål"
 
+#. settings-schema.json->style->options
 msgid "White Note - Blue Button"
 msgstr "Vitt ark - Blå nål"
 
+#. settings-schema.json->style->options
 msgid "White Note - Green Button"
 msgstr "Vitt ark - Grön nål"
 
+#. settings-schema.json->style->options
 msgid "White Note - Red Button"
 msgstr "Vitt ark - Röd nål"
 
+#. settings-schema.json->style->options
 msgid "White Note - Yellow Button"
 msgstr "Vitt ark - Gul nål"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Black Clip"
 msgstr "Gult ark - Svart gem"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Blue Clip"
 msgstr "Gult ark - Blått gem"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Green Clip"
 msgstr "Gult ark - Grönt gem"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Jingle Clip"
 msgstr "Gult ark - Randigt gem"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Red Clip"
 msgstr "Gult ark - Rött gem"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Yellow Clip"
 msgstr "Gult ark - Gult gem"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Magnet"
 msgstr "Vitt ark - Svart magnet"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Blue Magnet"
 msgstr "Gult ark - Blå magnet"
 
+#. settings-schema.json->style->options
 msgid "White Note - Lines and Red Magnet"
 msgstr "Vitt ark - Linjer och röd magnet"
 
+#. settings-schema.json->style->options
 msgid "Black Note - White Magnet"
 msgstr "Svart ark - Vit magnet"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Yellow Magnet"
 msgstr "Gult ark - Gul magnet"
 
+#. settings-schema.json->style->options
 msgid "Blue Paint Strokes"
 msgstr "Blåa penseldrag"
 
+#. settings-schema.json->style->options
 msgid "Green Paint Strokes"
 msgstr "Gröna penseldrag"
 
+#. settings-schema.json->style->options
 msgid "Purple Paint Strokes"
 msgstr "Lila penseldrag"
 
+#. settings-schema.json->style->options
 msgid "Red Paint Strokes"
 msgstr "Röda penseldrag"
 
+#. settings-schema.json->style->options
 msgid "Yellow Paint Strokes"
 msgstr "Gula penseldrag"
 
+#. settings-schema.json->style->options
 msgid "White Note - Silver Spiral"
 msgstr "Vitt ark - Silverspiral"
 
+#. settings-schema.json->style->options
 msgid "White Note - Silver Spiral 2"
 msgstr "Vitt ark - Silverspiral 2"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Spiral"
 msgstr "Vitt ark - Svart spiral"
 
+#. settings-schema.json->style->options
 msgid "White Note Large - Silver Spiral"
 msgstr "Vitt ark stor - Silverspiral"
 
+#. settings-schema.json->style->options
 msgid "Yellow Sticker"
 msgstr "Gul PostIt"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note (iOS Style)"
 msgstr "Gult ark (iOS-stil)"
 
+#. settings-schema.json->style->options
 msgid "Birch Bark"
 msgstr "Björknäver"
 
+#. settings-schema.json->style->options
 msgid "Burned Paper"
 msgstr "Bränt papper"
 
+#. settings-schema.json->style->options
 msgid "Clay Tablet"
 msgstr "Lertavla"
 
+#. settings-schema.json->style->options
 msgid "Coffee Stained"
 msgstr "Kaffefläckat"
 
+#. settings-schema.json->style->options
 msgid "Clipboard"
 msgstr "Skrivplatta"
 
+#. settings-schema.json->style->options
+msgid "None"
+msgstr ""
+
+#. settings-schema.json->style->tooltip
+msgid "Select the background graphic you would like to use."
+msgstr "Välj den bakgrundsgrafik du vill använda."
+
+#. settings-schema.json->bg-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->bg-color->tooltip
+#, fuzzy
+msgid "Set the background color of this desklet."
+msgstr "Ange textfärg för anteckningar."
+
+#. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"
 msgstr "Dölj dekorationer"
 
+#. settings-schema.json->font->description
 msgid "Font"
 msgstr "Teckensnitt"
 
-msgid "Bold"
-msgstr "Fet"
+#. settings-schema.json->size-font->units
+msgid "pixels"
+msgstr "pixlar"
 
-msgid "Italic"
-msgstr "Kursiv"
-
+#. settings-schema.json->size-font->description
 msgid "Font size"
 msgstr "Teckenstorlek"
 
+#. settings-schema.json->size-font->tooltip
+#, fuzzy
+msgid "Increase or decrease the note font size."
+msgstr ""
+"Öka eller minska storleken på det här skrivbordsprogrammet, med denna "
+"skalfaktor."
+
+#. settings-schema.json->font-bold->description
+msgid "Bold"
+msgstr "Fet"
+
+#. settings-schema.json->font-italic->description
+msgid "Italic"
+msgstr "Kursiv"
+
+#. settings-schema.json->text-color->description
+msgid "Text color"
+msgstr "Textfärg"
+
+#. settings-schema.json->text-color->tooltip
+msgid "Set the text color of this desklet."
+msgstr "Ange textfärg för anteckningar."
+
+#. settings-schema.json->scale-size->units
+msgid "scale factor"
+msgstr "skalfaktor"
+
+#. settings-schema.json->scale-size->description
+msgid "Desklet size"
+msgstr "Programstorlek"
+
+#. settings-schema.json->scale-size->tooltip
 msgid "Increase or decrease the size of this desklet using this scale factor."
 msgstr ""
 "Öka eller minska storleken på det här skrivbordsprogrammet, med denna "
 "skalfaktor."
 
-msgid "Set the text color of this desklet."
-msgstr "Ange textfärg för anteckningar."
-
-msgid "Text color"
-msgstr "Textfärg"
-
-msgid "Desklet size"
-msgstr "Programstorlek"
-
-msgid "pixels"
-msgstr "pixlar"
-
-msgid "scale factor"
-msgstr "skalfaktor"
-
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Anpassad programetikett (synlig endast om dekorationer är aktiverade)."
-
+#. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
 msgstr "Använd anpassad programetikett"
 
+#. settings-schema.json->use-custom-label->tooltip
 msgid "Checking this box allows you to set a custom label in the field below."
 msgstr "Aktivering låter dig ange en anpassad etikett i fältet nedan."
 
+#. settings-schema.json->custom-label->description
 msgid "Custom desklet label"
 msgstr "Anpassad programetikett"
 
+#. settings-schema.json->custom-label->tooltip
 msgid ""
 "Set your custom label here. This field is unavailable unless the checkbox "
 "above is enabled."

--- a/notes@schorschii/files/notes@schorschii/po/sv.po
+++ b/notes@schorschii/files/notes@schorschii/po/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: notes@schorschii\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2019-02-27 06:19+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -22,11 +22,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr ""
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -38,7 +38,7 @@ msgstr ""
 "\n"
 "Klicka här för att redigera."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Notepad"
 

--- a/notes@schorschii/files/notes@schorschii/po/tr.po
+++ b/notes@schorschii/files/notes@schorschii/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 15:16-0100\n"
+"POT-Creation-Date: 2024-09-28 12:45-0400\n"
 "PO-Revision-Date: 2018-11-27 15:10+0300\n"
 "Last-Translator: Gökhan GÖKKAYA <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye <gokhanlnx@gmail.com>\n"
@@ -22,11 +22,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:133
+#. desklet.js:133
 msgid "Refresh"
 msgstr ""
 
-#: desklet.js:146
+#. desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -38,7 +38,7 @@ msgstr ""
 "\n"
 "Düzenlemek için buraya tıklayınız."
 
-#: desklet.js:272
+#. desklet.js:272
 msgid "Notepad"
 msgstr "Not defteri"
 

--- a/notes@schorschii/files/notes@schorschii/po/tr.po
+++ b/notes@schorschii/files/notes@schorschii/po/tr.po
@@ -6,21 +6,27 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-01-12 18:07+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
+"issues\n"
+"POT-Creation-Date: 2024-09-28 15:16-0100\n"
 "PO-Revision-Date: 2018-11-27 15:10+0300\n"
+"Last-Translator: Gökhan GÖKKAYA <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye <gokhanlnx@gmail.com>\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: ..\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Last-Translator: Gökhan GÖKKAYA <gokhanlnx@gmail.com>\n"
-"Language: tr\n"
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#: desklet.js:109
+#: desklet.js:133
+msgid "Refresh"
+msgstr ""
+
+#: desklet.js:146
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -32,216 +38,312 @@ msgstr ""
 "\n"
 "Düzenlemek için buraya tıklayınız."
 
-#: desklet.js:172
+#: desklet.js:272
 msgid "Notepad"
 msgstr "Not defteri"
 
-msgid "Note"
-msgstr "Not"
-
+#. metadata.json->description
 msgid "A desklet to display notes including various themes."
 msgstr "Notları çeşitli temalarla gösteren bir masaüstü uygulamacığı."
 
-msgid "Settings for notes@schorschii"
-msgstr "notes@schorschii için Ayarlar"
+#. metadata.json->name
+#. settings-schema.json->note-section->title
+msgid "Note"
+msgstr "Not"
 
+#. settings-schema.json->general-page->title
+#. settings-schema.json->general-section->title
 msgid "General"
 msgstr "Genel"
 
-msgid "Path to note text file"
-msgstr "Not metin dosyasının yolu"
-
-msgid "Select your text file, where to read from and save to."
-msgstr "Okumak ve kaydetmek için metin dosyasını seçin."
-
-msgid "Command for editing this note (on mouse click)"
-msgstr "Bu notu düzenlemek için komut (üstüne tıklandığında)"
-
-msgid "%f will replaced by the text file path."
-msgstr "%f metin dosyası yolu ile değiştirilecek."
-
+#. settings-schema.json->visual-page->title
+#. settings-schema.json->visual-section->title
 msgid "Visual"
 msgstr "Görsel"
 
-msgid "Select the background graphic you would like to use."
-msgstr "Kullanmak istediğiniz arkaplan grafiğini seçin."
+#. settings-schema.json->label-section->title
+msgid "Label"
+msgstr ""
 
+#. settings-schema.json->note-taking-method->description
+msgid "Note Taking Method"
+msgstr ""
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Text File"
+msgstr "Metin rengi"
+
+#. settings-schema.json->note-taking-method->options
+#, fuzzy
+msgid "Desklet Settings"
+msgstr "Masaüstü uygulamacığının boyutu"
+
+#. settings-schema.json->file->description
+msgid "Path to note text file"
+msgstr "Not metin dosyasının yolu"
+
+#. settings-schema.json->file->tooltip
+msgid "Select your text file, where to read from and save to."
+msgstr "Okumak ve kaydetmek için metin dosyasını seçin."
+
+#. settings-schema.json->edit-cmd->description
+msgid "Command for editing this note (on mouse click)"
+msgstr "Bu notu düzenlemek için komut (üstüne tıklandığında)"
+
+#. settings-schema.json->edit-cmd->tooltip
+msgid "%f will replaced by the text file path."
+msgstr "%f metin dosyası yolu ile değiştirilecek."
+
+#. settings-schema.json->note-text->description
+msgid "Write Your Note"
+msgstr ""
+
+#. settings-schema.json->style->description
 msgid "Notes style"
 msgstr "Notların tarzı"
 
-msgid "Yellow"
-msgstr "Sarı"
-
-msgid "White"
-msgstr "Beyaz"
-
+#. settings-schema.json->style->options
 msgid "Blank Note - Black"
 msgstr "Boş Not - Siyah"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Blue"
 msgstr "Boş Not - Mavi"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Green"
 msgstr "Boş Not - Yeşil"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Orange"
 msgstr "Boş Not - Turuncu"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Purple"
 msgstr "Boş Not - Mor"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - White"
 msgstr "Boş Not - Beyaz"
 
+#. settings-schema.json->style->options
 msgid "Blank Note - Yellow"
 msgstr "Boş Not - Sarı"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Button"
 msgstr "Beyaz Not - Siyah Raptiye"
 
+#. settings-schema.json->style->options
 msgid "White Note - Blue Button"
 msgstr "Beyaz Not - Mavi Raptiye"
 
+#. settings-schema.json->style->options
 msgid "White Note - Green Button"
 msgstr "Beyaz Not - Yeşil Raptiye"
 
+#. settings-schema.json->style->options
 msgid "White Note - Red Button"
 msgstr "Beyaz Not - Kırmızı Raptiye"
 
+#. settings-schema.json->style->options
 msgid "White Note - Yellow Button"
 msgstr "Beyaz Not - Sarı Raptiye"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Black Clip"
 msgstr "Sarı Not - Siyah Ataç"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Blue Clip"
 msgstr "Sarı Not - Mavi Ataç"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Green Clip"
 msgstr "Sarı Not - Yeşil Ataç"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Jingle Clip"
 msgstr "Sarı Not - Renkli Ataç"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Red Clip"
 msgstr "Sarı Not - Kırmızı Ataç"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Yellow Clip"
 msgstr "Sarı Not - Sarı Ataç"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Magnet"
 msgstr "Beyaz Not- Siyah Mıknatıs"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Blue Magnet"
 msgstr "Sarı Not- Mavi Mıknatıs"
 
+#. settings-schema.json->style->options
 msgid "White Note - Lines and Red Magnet"
 msgstr "Beyaz Not - Satırlar ve Kırmızı Mıknatıs"
 
+#. settings-schema.json->style->options
 msgid "Black Note - White Magnet"
 msgstr "Siyah Not- Beyaz Mıknatıs"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note - Yellow Magnet"
 msgstr "Sarı Not- Sarı Mıknatıs"
 
+#. settings-schema.json->style->options
 msgid "Blue Paint Strokes"
 msgstr "Mavi Fırça Darbesi"
 
+#. settings-schema.json->style->options
 msgid "Green Paint Strokes"
 msgstr "Yeşil Fırça Darbesi"
 
+#. settings-schema.json->style->options
 msgid "Purple Paint Strokes"
 msgstr "Turuncu Fırça Darbesi"
 
+#. settings-schema.json->style->options
 msgid "Red Paint Strokes"
 msgstr "Kırmızı Fırça Darbesi"
 
+#. settings-schema.json->style->options
 msgid "Yellow Paint Strokes"
 msgstr "Sarı Fırça Darbesi"
 
+#. settings-schema.json->style->options
 msgid "White Note - Silver Spiral"
 msgstr "Beyaz Not - Gümüş Sarmal"
 
+#. settings-schema.json->style->options
 msgid "White Note - Silver Spiral 2"
 msgstr "Beyaz Not - Gümüş Sarmal 2"
 
+#. settings-schema.json->style->options
 msgid "White Note - Black Spiral"
 msgstr "Beyaz Not - Siyah Sarmal"
 
+#. settings-schema.json->style->options
 msgid "White Note Large - Silver Spiral"
 msgstr "Beyaz Not Büyük - Gümüş Sarmal"
 
+#. settings-schema.json->style->options
 msgid "Yellow Sticker"
 msgstr "Sarı Yapışkan"
 
+#. settings-schema.json->style->options
 msgid "Yellow Note (iOS Style)"
 msgstr "Sarı Not (iOS Tarzı)"
 
+#. settings-schema.json->style->options
 msgid "Birch Bark"
 msgstr "Huş Kabuğu"
 
+#. settings-schema.json->style->options
 msgid "Burned Paper"
 msgstr "Yanmış Kağıt"
 
+#. settings-schema.json->style->options
 msgid "Clay Tablet"
 msgstr "Kil Levha"
 
+#. settings-schema.json->style->options
 msgid "Coffee Stained"
 msgstr "Kahve Lekeli"
 
+#. settings-schema.json->style->options
 msgid "Clipboard"
 msgstr "Pano"
 
+#. settings-schema.json->style->options
+msgid "None"
+msgstr ""
+
+#. settings-schema.json->style->tooltip
+msgid "Select the background graphic you would like to use."
+msgstr "Kullanmak istediğiniz arkaplan grafiğini seçin."
+
+#. settings-schema.json->bg-color->description
+msgid "Background color"
+msgstr ""
+
+#. settings-schema.json->bg-color->tooltip
+#, fuzzy
+msgid "Set the background color of this desklet."
+msgstr "Bu masaüstü uygulamacığının metin rengini ayarla"
+
+#. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"
 msgstr "Süslemeleri gizle"
 
+#. settings-schema.json->font->description
 msgid "Font"
 msgstr "Yazıtipi"
 
-msgid "Bold"
-msgstr "Kalın"
+#. settings-schema.json->size-font->units
+msgid "pixels"
+msgstr "piksel"
 
-msgid "Italic"
-msgstr "Eğik"
-
+#. settings-schema.json->size-font->description
 msgid "Font size"
 msgstr "Yazıtipi boyutu"
 
+#. settings-schema.json->size-font->tooltip
+#, fuzzy
+msgid "Increase or decrease the note font size."
+msgstr ""
+"Bu ölçü çarpanını kullanarak bu masaüstü uygulamacığının boyutunu artırın "
+"veya azaltın."
+
+#. settings-schema.json->font-bold->description
+msgid "Bold"
+msgstr "Kalın"
+
+#. settings-schema.json->font-italic->description
+msgid "Italic"
+msgstr "Eğik"
+
+#. settings-schema.json->text-color->description
+msgid "Text color"
+msgstr "Metin rengi"
+
+#. settings-schema.json->text-color->tooltip
+msgid "Set the text color of this desklet."
+msgstr "Bu masaüstü uygulamacığının metin rengini ayarla"
+
+#. settings-schema.json->scale-size->units
+msgid "scale factor"
+msgstr "ölçü çarpanı"
+
+#. settings-schema.json->scale-size->description
+msgid "Desklet size"
+msgstr "Masaüstü uygulamacığının boyutu"
+
+#. settings-schema.json->scale-size->tooltip
 msgid "Increase or decrease the size of this desklet using this scale factor."
 msgstr ""
 "Bu ölçü çarpanını kullanarak bu masaüstü uygulamacığının boyutunu artırın "
 "veya azaltın."
 
-msgid "Set the text color of this desklet."
-msgstr "Bu masaüstü uygulamacığının metin rengini ayarla"
-
-msgid "Text color"
-msgstr "Metin rengi"
-
-msgid "Desklet size"
-msgstr "Masaüstü uygulamacığının boyutu"
-
-msgid "pixels"
-msgstr "piksel"
-
-msgid "scale factor"
-msgstr "ölçü çarpanı"
-
-msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Masaüstü uygulamacığı özel etiketi (sadece süslemeler etkinse görünür)"
-
+#. settings-schema.json->use-custom-label->description
 msgid "Use a custom desklet label"
 msgstr "Masaüstü uygulamacığı için özel bir etiketi kullan"
 
+#. settings-schema.json->use-custom-label->tooltip
 msgid "Checking this box allows you to set a custom label in the field below."
 msgstr ""
-"Bu kutuyu işaretlemek, aşağıda açılacak alandan özel bir etiket "
-"ayarlamanıza izin verir."
+"Bu kutuyu işaretlemek, aşağıda açılacak alandan özel bir etiket ayarlamanıza "
+"izin verir."
 
+#. settings-schema.json->custom-label->description
 msgid "Custom desklet label"
 msgstr "Özel masaüstü uygulamacığı etiketi"
 
+#. settings-schema.json->custom-label->tooltip
 msgid ""
 "Set your custom label here. This field is unavailable unless the checkbox "
 "above is enabled."

--- a/notes@schorschii/files/notes@schorschii/settings-schema.json
+++ b/notes@schorschii/files/notes@schorschii/settings-schema.json
@@ -15,7 +15,7 @@
         },
         "visual-page": {
             "type": "page",
-            "title": "Style",
+            "title": "Visual",
             "sections": [
                 "visual-section",
                 "label-section"
@@ -35,7 +35,7 @@
             "keys": [
                 "file",
                 "edit-cmd",
-                "note-text-box"
+                "note-text"
             ]
         },
         "visual-section": {
@@ -88,7 +88,7 @@
         "tooltip": "%f will replaced by the text file path.",
         "allow-none": true
     },
-    "note-text-box": {
+    "note-text": {
         "type": "textview",
         "description": "Write Your Note",
         "dependency": "note-taking-method=desklet",

--- a/notes@schorschii/files/notes@schorschii/settings-schema.json
+++ b/notes@schorschii/files/notes@schorschii/settings-schema.json
@@ -1,37 +1,105 @@
 {
-    "head0": {
-        "type": "header",
-        "description": "Settings for notes@schorschii"
+    "layout": {
+        "type": "layout",
+        "pages": [
+            "general-page",
+            "visual-page"
+        ],
+        "general-page": {
+            "type": "page",
+            "title": "General",
+            "sections": [
+                "general-section",
+                "note-section"
+            ]
+        },
+        "visual-page": {
+            "type": "page",
+            "title": "Style",
+            "sections": [
+                "visual-section",
+                "label-section"
+            ]
+        },
+        "general-section": {
+            "type": "section",
+            "title": "General",
+            "keys": [
+                "style",
+                "note-taking-method"
+            ]
+        },
+        "note-section": {
+            "type": "section",
+            "title": "Note",
+            "keys": [
+                "file",
+                "edit-cmd",
+                "note-text-box"
+            ]
+        },
+        "visual-section": {
+            "type": "section",
+            "title": "Visual",
+            "keys": [
+                "style",
+                "scale-size",
+                "hide-decorations",
+                "bg-color",
+                "font",
+                "size-font",
+                "font-bold",
+                "font-italic",
+                "text-color"
+            ]
+        },
+        "label-section": {
+            "type": "section",
+            "title": "Label",
+            "dependency": "!hide-decorations",
+            "keys": [
+                "use-custom-label",
+                "custom-label"
+            ]
+        }
     },
-
-    "head1": {
-        "type": "header",
-        "description": "General"
+    "note-taking-method": {
+        "type": "combobox",
+        "default": "file",
+        "description": "Note Taking Method",
+        "options": {
+            "Text File": "file",
+            "Desklet Settings": "desklet"
+        }
     },
     "file": {
         "type": "filechooser",
+        "dependency": "note-taking-method=file",
         "default": "",
         "description": "Path to note text file",
         "tooltip": "Select your text file, where to read from and save to.",
-        "allow-none" : true
+        "allow-none": true
     },
     "edit-cmd": {
         "type": "entry",
+        "dependency": "note-taking-method=file",
         "default": "xed %f",
         "description": "Command for editing this note (on mouse click)",
         "tooltip": "%f will replaced by the text file path.",
-        "allow-none" : true
+        "allow-none": true
     },
-
-    "head2": {
-        "type": "header",
-        "description": "Visual"
+    "note-text-box": {
+        "type": "textview",
+        "description": "Write Your Note",
+        "dependency": "note-taking-method=desklet",
+        "default": "",
+        "height": 200
     },
-    "style" : {
+    "style": {
         "type": "combobox",
-        "default" : "Niki_black_magnet",
-        "description" : "Notes style",
-        "options" : {
+        "default": "Niki_black_magnet",
+        "description": "Notes style",
+        "options": {
             "Blank Note - Black": "Niki_blank_black",
             "Blank Note - Blue": "Niki_blank_blue",
             "Blank Note - Green": "Niki_blank_green",
@@ -39,37 +107,31 @@
             "Blank Note - Purple": "Niki_blank_purple",
             "Blank Note - White": "Niki_blank_white",
             "Blank Note - Yellow": "Niki_blank_yellow",
-
             "White Note - Black Button": "Niki_black_button",
             "White Note - Blue Button": "Niki_blue_button",
             "White Note - Green Button": "Niki_green_button",
             "White Note - Red Button": "Niki_red_button",
             "White Note - Yellow Button": "Niki_yellow_button",
-
             "Yellow Note - Black Clip": "Niki_black_clip",
             "Yellow Note - Blue Clip": "Niki_blue_clip",
             "Yellow Note - Green Clip": "Niki_green_clip",
             "Yellow Note - Jingle Clip": "Niki_jingle_clip",
             "Yellow Note - Red Clip": "Niki_red_clip",
             "Yellow Note - Yellow Clip": "Niki_yellow_clip",
-
             "White Note - Black Magnet": "Niki_black_magnet",
             "Yellow Note - Blue Magnet": "Niki_blue_magnet",
             "White Note - Lines and Red Magnet": "Niki_red_magnet",
             "Black Note - White Magnet": "Niki_white_magnet",
             "Yellow Note - Yellow Magnet": "Niki_yellow_magnet",
-
             "Blue Paint Strokes": "Niki_blue_paint_strokes",
             "Green Paint Strokes": "Niki_green_paint_strokes",
             "Purple Paint Strokes": "Niki_purple_paint_strokes",
             "Red Paint Strokes": "Niki_red_paint_strokes",
             "Yellow Paint Strokes": "Niki_yellow_paint_strokes",
-
             "White Note - Silver Spiral": "schorschii_white",
             "White Note - Silver Spiral 2": "Niki_white",
             "White Note - Black Spiral": "Niki_white_black_spiral",
             "White Note Large - Silver Spiral": "Niki_white_large",
-
             "Yellow Sticker": "Niki_sticker",
             "Yellow Note (iOS Style)": "schorschii_yellow",
             "Birch Bark": "Niki_birch_bark",
@@ -77,10 +139,9 @@
             "Clay Tablet": "Niki_clay_tablet",
             "Coffee Stained": "Niki_coffee_stained",
             "Clipboard": "Niki_board_tablet",
-
             "None": "none"
         },
-        "tooltip" : "Select the background graphic you would like to use."
+        "tooltip": "Select the background graphic you would like to use."
     },
     "bg-color": {
         "type": "colorchooser",
@@ -90,7 +151,7 @@
         "dependency": "style=none"
     },
     "hide-decorations": {
-        "type": "checkbox",
+        "type": "switch",
         "description": "Hide decorations",
         "default": false
     },
@@ -134,11 +195,6 @@
         "units": "scale factor",
         "description": "Desklet size",
         "tooltip": "Increase or decrease the size of this desklet using this scale factor."
-    },
-
-    "head3": {
-        "type": "header",
-        "description": "Custom desklet label (only visible if decorations are enabled)"
     },
     "use-custom-label": {
         "type": "checkbox",


### PR DESCRIPTION
Hello @schorschii,
With this PR I generally made two changes:
1. Reorganize settings, dividing it in two sections **General**, and **Visual**
2. Allow taking notes in the Desklet with the **textview** settings component type. This is a toggeable option, the default is still the text-based note, but you can edit notes directly in the desklet settings now, which makes sense since each Desklet will have its own settings instance.

Example Picture:

![Captura de ecrã de 2024-09-28 06-52-54](https://github.com/user-attachments/assets/87cc7325-bef9-4386-8089-e4c486f4b681)