### PR TITLE
notes@schorschii: update translations

### DIFF
--- a/notes@schorschii/files/notes@schorschii/po/ca.po
+++ b/notes@schorschii/files/notes@schorschii/po/ca.po
@@ -58,8 +58,10 @@ msgid "Visual"
 msgstr "Visual"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
+"Etiqueta de miniaplicació d'escriptori personalitzada (només és visible si "
+"les decoracions estan habilitades)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/da.po
+++ b/notes@schorschii/files/notes@schorschii/po/da.po
@@ -58,8 +58,8 @@ msgid "Visual"
 msgstr "Visuel"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
-msgstr ""
+msgid "Custom desklet label (only visible if decorations are enabled)"
+msgstr "Tilpasset etiket (kun synlig hvis boksen rundt om er aktiveret)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/de.po
+++ b/notes@schorschii/files/notes@schorschii/po/de.po
@@ -57,22 +57,22 @@ msgid "Visual"
 msgstr "Aussehen"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
-msgstr ""
+msgid "Custom desklet label (only visible if decorations are enabled)"
+msgstr ""Eigenes Deskletlabel (nur sichtbar wenn Dekorationen aktiviert sind)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"
-msgstr ""
+msgstr "Notizmethode"
 
 #. settings-schema.json->note-taking-method->options
 #, fuzzy
 msgid "Text File"
-msgstr "Textfarbe"
+msgstr "Textdatei"
 
 #. settings-schema.json->note-taking-method->options
 #, fuzzy
 msgid "Desklet Settings"
-msgstr "Deskletgröße"
+msgstr "Desklet-Einstellungen"
 
 #. settings-schema.json->file->description
 msgid "Path to note text file"

--- a/notes@schorschii/files/notes@schorschii/po/de.po
+++ b/notes@schorschii/files/notes@schorschii/po/de.po
@@ -58,7 +58,7 @@ msgstr "Aussehen"
 
 #. settings-schema.json->label-section->title
 msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""Eigenes Deskletlabel (nur sichtbar wenn Dekorationen aktiviert sind)"
+msgstr "Eigenes Deskletlabel (nur sichtbar wenn Dekorationen aktiviert sind)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/es.po
+++ b/notes@schorschii/files/notes@schorschii/po/es.po
@@ -59,8 +59,10 @@ msgid "Visual"
 msgstr "Visual"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
-msgstr "Etiqueta"
+msgid "Custom desklet label (only visible if decorations are enabled)"
+msgstr ""
+"Etiqueta personalizada del desklet (solo visible si las decoraciones están "
+"habilitadas)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/fr.po
+++ b/notes@schorschii/files/notes@schorschii/po/fr.po
@@ -57,8 +57,10 @@ msgid "Visual"
 msgstr "Visuel"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
+"Étiquette de desklet personnalisée (visible seulement si décorations "
+"activées)" 
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/hu.po
+++ b/notes@schorschii/files/notes@schorschii/po/hu.po
@@ -58,8 +58,9 @@ msgid "Visual"
 msgstr "Vizuális"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
+"Egyéni asztali címke (csak akkor látható, ha a dekoráció engedélyezve van)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/it.po
+++ b/notes@schorschii/files/notes@schorschii/po/it.po
@@ -57,8 +57,10 @@ msgid "Visual"
 msgstr "Visuale"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
+"Etichetta del desklet personalizzata (visibile solo se le decorazioni sono "
+"abilitate)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/nl.po
+++ b/notes@schorschii/files/notes@schorschii/po/nl.po
@@ -57,8 +57,9 @@ msgid "Visual"
 msgstr "Visueel"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
+"Aangepast deskletlabel (alleen zichtbaar als decoraties zijn ingeschakeld)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/notes@schorschii.pot
+++ b/notes@schorschii/files/notes@schorschii/po/notes@schorschii.pot
@@ -53,7 +53,7 @@ msgid "Visual"
 msgstr ""
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
 
 #. settings-schema.json->note-taking-method->description

--- a/notes@schorschii/files/notes@schorschii/po/pt.po
+++ b/notes@schorschii/files/notes@schorschii/po/pt.po
@@ -58,8 +58,10 @@ msgid "Visual"
 msgstr "Visual"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
-msgstr "Etiqueta"
+msgid "Custom desklet label (only visible if decorations are enabled)"
+msgstr ""
+"Rótulo personalizado do desklet (visível apenas se as decorações não "
+"estiverem escondidas)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/pt_BR.po
+++ b/notes@schorschii/files/notes@schorschii/po/pt_BR.po
@@ -60,8 +60,10 @@ msgid "Visual"
 msgstr "Visual"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
+"Rótulo personalizado do desklet (visível apenas se as decorações não "
+"estiverem escondidas)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/ro.po
+++ b/notes@schorschii/files/notes@schorschii/po/ro.po
@@ -59,8 +59,8 @@ msgid "Visual"
 msgstr "Vizual"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
-msgstr ""
+msgid "Custom desklet label (only visible if decorations are enabled)"
+msgstr "Etichetă personalizată pentru desklet (vizibilă numai dacă sunt activate decorațiile)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/ru.po
+++ b/notes@schorschii/files/notes@schorschii/po/ru.po
@@ -58,8 +58,8 @@ msgid "Visual"
 msgstr "Отображение"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
-msgstr ""
+msgid "Custom desklet label (only visible if decorations are enabled)"
+msgstr "Настройка названия десклета (только при включенных декорациях)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/sv.po
+++ b/notes@schorschii/files/notes@schorschii/po/sv.po
@@ -62,8 +62,9 @@ msgid "Visual"
 msgstr "Visuellt"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
+"Anpassad programetikett (synlig endast om dekorationer är aktiverade)."
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/po/tr.po
+++ b/notes@schorschii/files/notes@schorschii/po/tr.po
@@ -62,8 +62,9 @@ msgid "Visual"
 msgstr "Görsel"
 
 #. settings-schema.json->label-section->title
-msgid "Label"
+msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
+"Masaüstü uygulamacığı özel etiketi (sadece süslemeler etkinse görünür)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"

--- a/notes@schorschii/files/notes@schorschii/settings-schema.json
+++ b/notes@schorschii/files/notes@schorschii/settings-schema.json
@@ -55,7 +55,7 @@
         },
         "label-section": {
             "type": "section",
-            "title": "Label",
+            "title": "Custom desklet label (only visible if decorations are enabled)",
             "dependency": "!hide-decorations",
             "keys": [
                 "use-custom-label",


### PR DESCRIPTION
This adds the note that custom labels are only visible when decorations are enabled again after #1293 and updates the German translation.