### PR TITLE
[analog-clock@cobinja.de] Fix german translation

### DIFF
--- a/analog-clock@cobinja.de/files/analog-clock@cobinja.de/po/de.po
+++ b/analog-clock@cobinja.de/files/analog-clock@cobinja.de/po/de.po
@@ -27,15 +27,15 @@ msgstr "CobiAnalogClock"
 
 #. metadata.json->description
 msgid "An analog clock desklet"
-msgstr "Ein Analoguhr-Desklet"
+msgstr "Ein Desklet mit einer analogen Uhr"
 
 #: 2.8/settings.ui:7 3.0/settings.ui:7
 msgid "Analog Clock Settings"
-msgstr "Analoguhr-Einstellungen"
+msgstr "Einstellungen für CobiAnalogClock"
 
 #: 2.8/settings.ui:99 3.0/settings.ui:99
 msgid "Theme"
-msgstr "Theme"
+msgstr "Thema"
 
 #: 2.8/settings.ui:138 3.0/settings.ui:138
 msgid "Size"
@@ -47,11 +47,11 @@ msgstr "Sekunden anzeigen"
 
 #: 2.8/settings.ui:220 3.0/settings.ui:220
 msgid "Hide decorations"
-msgstr "Dekorationen ausblenden"
+msgstr "Verzierungen ausblenden"
 
 #: 2.8/settings.ui:259 3.0/settings.ui:259
 msgid "Use specific timezone"
-msgstr "Bestimmte Zeitzone verwenden"
+msgstr "Spezifische Zeitzone verwenden"
 
 #: 2.8/settings.ui:297 3.0/settings.ui:297
 msgid "Display Timezone"


### PR DESCRIPTION
Originally, some of the german translations were messed up by https://github.com/linuxmint/cinnamon-spices-desklets/pull/1098/files#diff-61e353a473acee02d5744fe0f681529d71f37e3f63a1e9b3d514a05516e3a454

https://github.com/linuxmint/cinnamon-spices-desklets/pull/1352 fixed those but also changed some that were unchanged by the commit mentioned above.

THis PR reverts those changes.

I personally agree that "Dekorationen" would be more suitable than "Verzierungen". But: Cinnamon Settings -> Desklets -> "Allgemeine Einstellungen" -> "Gestaltung der Desklets" uses the word "Verzierungen" so I used it as well to avoid confusion. The other ones are my personal preference as the original author of this desklet.