### PR TITLE
[googleCalendar@javahelps.com] Minor bugfixes

### DIFF
--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/desklet.js
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/desklet.js
@@ -134,7 +134,7 @@ GoogleCalendarDesklet.prototype = {
      */
     onCalendarParamsChanged() {
         this.setCalendarName();
-        if (this.updateID > 0) {
+        if (this.updateID) {
             Mainloop.source_remove(this.updateID);
         }
         this.updateID = null;
@@ -170,7 +170,7 @@ GoogleCalendarDesklet.prototype = {
      * Called when the desklet is removed.
      */
     on_desklet_removed() {
-        if (this.updateID > 0) {
+        if (this.updateID) {
             Mainloop.source_remove(this.updateID);
         }
         this.updateID = null;

--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/metadata.json
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/metadata.json
@@ -4,5 +4,6 @@
     "name": "Google Calendar",
     "max-instances": "10",
     "prevent-decorations": true,
-    "cinnamon-version": ["3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6"]
+    "cinnamon-version": ["3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6"],
+    "author": "slgobinath"
 }

--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/settings-schema.json
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/settings-schema.json
@@ -113,7 +113,7 @@
     "default": 7,
     "type": "spinbutton",
     "min": 1,
-    "max": 30,
+    "max": 62,
     "description": "Number of days to include",
     "tooltip": "Show the agenda for these number of days",
     "units": "days",


### PR DESCRIPTION
@slgobinath

Your fabulous desklet was flooding `~/.xsession-errors` with error messages about `Mainloop.source_remove()`. This PR fixes that.

Also, the maximum “Number of days to include” is now set to 62 (i.e. 2 months)... because I got tired of doing that every time I installed.

I hope you'll like all that.

Regards
Claudiux