### PR TITLE
[googleCalendar@javahelps.com] Improved compatibility with Cinnamon 6.4 - Bugfixes

### DIFF
--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/desklet.js
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/desklet.js
@@ -134,10 +134,10 @@ GoogleCalendarDesklet.prototype = {
      */
     onCalendarParamsChanged() {
         this.setCalendarName();
-        if (this.updateID) {
-            Mainloop.source_remove(this.updateID);
-        }
-        this.updateID = null;
+        //~ if (this.updateID) {
+            //~ Mainloop.source_remove(this.updateID);
+        //~ }
+        //~ this.updateID = null;
         this.retrieveEventsIfAuthorized();
     },
 


### PR DESCRIPTION
@slgobinath 
These changes avoid errors on Cinnamon 6.4, by avoiding the use of `Mainloop.source_remove()` and adding the _Open Google Calendar_ menu item when it is sure that _this._menu_ exists.