### PR TITLE
system-monitor-graph@rcassani: Add support for amdgpu, and bump version

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
@@ -223,65 +223,41 @@ SystemMonitorGraph.prototype = {
               break;
 
           case "gpu":
-              switch (this.gpu_manufacturer) {
-                case "nvidia":
-                    switch (this.gpu_variable) {
-                        case "usage":
-                            this.get_nvidia_gpu_use();
-                            value = this.gpu_use / 100;
-                            text1 = _("GPU Usage");
-                            text2 = Math.round(this.gpu_use).toString() + "%";
-                            break;
-                        case "memory":
-                            this.get_nvidia_gpu_mem();
-                            let gpu_mem_use = 100 * this.gpu_mem[1] / this.gpu_mem[0];
-                            value = gpu_mem_use / 100;
-                            let gpumem_prefix = "";
-                            if (this.data_prefix_gpumem == 1) {
-                                // decimal prefix
-                                gpumem_prefix =  _("GB");
-                            } else {
-                                // binary prefix
-                                gpumem_prefix =  _("GiB");
-                            }
-                            text1 = _("GPU Memory");
-                            text2 = Math.round(gpu_mem_use).toString() + "%"
-                            text3 = this.gpu_mem[1].toFixed(1) + " / "
-                                  + this.gpu_mem[0].toFixed(1) + " " + gpumem_prefix;
-                            break;
+              switch (this.gpu_variable) {
+                  case "usage":
+                      switch (this.gpu_manufacturer) {
+                          case "nvidia":
+                              this.get_nvidia_gpu_use();
+                          case "amdgpu":
+                              this.get_amdgpu_gpu_use();
+                      }
+                      value = this.gpu_use / 100;
+                      text1 = _("GPU Usage");
+                      text2 = Math.round(this.gpu_use).toString() + "%";
+                      break;
+                  case "memory":
+                      switch (this.gpu_manufacturer) {
+                          case "nvidia":
+                              this.get_nvidia_gpu_mem();
+                          case "amdgpu":
+                              this.get_amdgpu_gpu_mem();
+                      }
+                      let gpu_mem_use = 100 * this.gpu_mem[1] / this.gpu_mem[0];
+                      value = gpu_mem_use / 100;
+                      let gpumem_prefix = "";
+                      if (this.data_prefix_gpumem == 1) {
+                          // decimal prefix
+                          gpumem_prefix =  _("GB");
+                      } else {
+                          // binary prefix
+                          gpumem_prefix =  _("GiB");
+                      }
+                      text1 = _("GPU Memory");
+                      text2 = Math.round(gpu_mem_use).toString() + "%"
+                      text3 = this.gpu_mem[1].toFixed(1) + " / "
+                            + this.gpu_mem[0].toFixed(1) + " " + gpumem_prefix;
+                      break;
                     }
-                    break;
-                case "amdgpu":
-                    switch (this.gpu_variable) {
-                        case "usage":
-                            this.get_amdgpu_gpu_use();
-                            value = this.gpu_use / 100;
-                            text1 = _("GPU Usage");
-                            text2 = Math.round(this.gpu_use).toString() + "%";
-                            break;
-                        case "memory":
-                            this.get_amdgpu_gpu_mem();
-                            let gpu_mem_use = 100 * this.gpu_mem[1] / this.gpu_mem[0];
-                            value = gpu_mem_use / 100;
-                            let gpumem_prefix = "";
-                            if (this.data_prefix_gpumem == 1) {
-                                // decimal prefix
-                                gpumem_prefix =  _("GB");
-                            } else {
-                                // binary prefix
-                                gpumem_prefix =  _("GiB");
-                            }
-                            text1 = _("GPU Memory");
-                            text2 = Math.round(gpu_mem_use).toString() + "%"
-                            text3 = this.gpu_mem[1].toFixed(1) + " / "
-                                  + this.gpu_mem[0].toFixed(1) + " " + gpumem_prefix;
-                            break;
-                    }
-                    break;
-                case "other":
-                    break;
-              }
-              break;
         }
 
         // concatenate new value

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "system-monitor-graph@rcassani",
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
-    "version": "1.6",
+    "version": "1.7",
     "prevent-decorations": true
 }

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
@@ -76,7 +76,8 @@
         "description": "GPU manufacturer",
         "tooltip": "Select the GPU manufacturer.",
         "options" : {
-            "NVIDIA" : "nvidia"
+            "NVIDIA" : "nvidia",
+            "AMDGPU" : "amdgpu"
         },
         "dependency": "type=gpu"
     },


### PR DESCRIPTION
This commit adds support for showing GPU and VRAM usage on GPUs which make use of the amdgpu driver.

It should be noted that GPU usage can be somewhat inaccurate because of the low sampling frequency.