### PR TITLE
Bugfix: `switch` structures in JavaScripts are fall-through

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
@@ -228,8 +228,10 @@ SystemMonitorGraph.prototype = {
                       switch (this.gpu_manufacturer) {
                           case "nvidia":
                               this.get_nvidia_gpu_use();
+                              break;
                           case "amdgpu":
                               this.get_amdgpu_gpu_use();
+                              break;
                       }
                       value = this.gpu_use / 100;
                       text1 = _("GPU Usage");
@@ -239,8 +241,10 @@ SystemMonitorGraph.prototype = {
                       switch (this.gpu_manufacturer) {
                           case "nvidia":
                               this.get_nvidia_gpu_mem();
+                              break;
                           case "amdgpu":
                               this.get_amdgpu_gpu_mem();
+                              break;
                       }
                       let gpu_mem_use = 100 * this.gpu_mem[1] / this.gpu_mem[0];
                       value = gpu_mem_use / 100;
@@ -257,7 +261,7 @@ SystemMonitorGraph.prototype = {
                       text3 = this.gpu_mem[1].toFixed(1) + " / "
                             + this.gpu_mem[0].toFixed(1) + " " + gpumem_prefix;
                       break;
-                    }
+              }
         }
 
         // concatenate new value

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "system-monitor-graph@rcassani",
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
-    "version": "1.7",
+    "version": "1.8",
     "prevent-decorations": true
 }


### PR DESCRIPTION
Fixes the bug reported in #1396 

The bug was introduced in #1394 as `switch` structures in JavaScript are fall-through. 
https://www.freecodecamp.org/news/fall-through-in-javascript-switch-statements/

So, with `NVIDIA` selected, both cases `nvidia` and `amd` were executed.
The fix just ends each GPU manufacturer case with `break;`

Also
- Updated version number
- Indentation change for clearer code

@Lazar-Kovacevic, the AMD support should be working properly
