### PR TITLE
xkcd@rjanja: Add XKCD alt text under the image & other changes (read desc)

### DIFF
--- a/xkcd@rjanja/files/xkcd@rjanja/desklet.js
+++ b/xkcd@rjanja/files/xkcd@rjanja/desklet.js
@@ -4,61 +4,76 @@ const Desklet = imports.ui.desklet;
 const Mainloop = imports.mainloop;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
-const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const GdkPixbuf = imports.gi.GdkPixbuf;
 const Cogl = imports.gi.Cogl;
 
-const Tooltips = imports.ui.tooltips;
 const PopupMenu = imports.ui.popupMenu;
 const Cinnamon = imports.gi.Cinnamon;
-const Soup = imports.gi.Soup
-let session
+const Soup = imports.gi.Soup;
+let session;
 if (Soup.get_major_version() == "2") {
     session = new Soup.SessionAsync();
-    Soup.Session.prototype.add_feature.call(session, new Soup.ProxyResolverDefault());
-} else { //Soup 3
+    Soup.Session.prototype.add_feature.call(
+        session,
+        new Soup.ProxyResolverDefault(),
+    );
+} else {
+    //Soup 3
     session = new Soup.Session();
 }
 
 const Gettext = imports.gettext;
 const UUID = "xkcd@rjanja";
 
-Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(str) {
-  return Gettext.dgettext(UUID, str);
+    return Gettext.dgettext(UUID, str);
 }
 
-function MyDesklet(metadata){
+function MyDesklet(metadata) {
     this._init(metadata);
 }
 
 MyDesklet.prototype = {
     __proto__: Desklet.Desklet.prototype,
 
-    download_file: function(url, localFilename, callback) {
+    download_file: function (url, localFilename, callback) {
         let outFile = Gio.file_new_for_path(localFilename);
         var outStream = new Gio.DataOutputStream({
-            base_stream:outFile.replace(null, false, Gio.FileCreateFlags.NONE, null)});
+            base_stream: outFile.replace(
+                null,
+                false,
+                Gio.FileCreateFlags.NONE,
+                null,
+            ),
+        });
 
-        var message = Soup.Message.new('GET', url);
+        var message = Soup.Message.new("GET", url);
 
         if (Soup.get_major_version() == "2") {
             session.queue_message(message, function (session, response) {
                 if (response.status_code !== Soup.KnownStatusCode.OK) {
-                    global.log("Error during download: response code " + response.status_code
-                        + ": " + response.reason_phrase + " - " + response.response_body.data);
+                    global.log(
+                        "Error during download: response code " +
+                            response.status_code +
+                            ": " +
+                            response.reason_phrase +
+                            " - " +
+                            response.response_body.data,
+                    );
                     callback(false, null);
                     return true;
                 }
 
                 try {
-                    let contents = message.response_body.flatten().get_as_bytes();  // For Soup 2.4
+                    let contents = message.response_body
+                        .flatten()
+                        .get_as_bytes(); // For Soup 2.4
                     outStream.write_bytes(contents, null);
                     outStream.close(null);
-                }
-                catch (e) {
+                } catch (e) {
                     global.logError("Site seems to be down. Error was:");
                     global.logError(e);
                     callback(false, null);
@@ -68,72 +83,85 @@ MyDesklet.prototype = {
                 callback(true, localFilename);
                 return false;
             });
-        } else { //Soup 3
-            session.send_and_read_async(message, Soup.MessagePriority.NORMAL, null, (session, response) => {
-                if (message.status_code !== Soup.Status.OK) {
-                    global.log("Error during download: response code " + message.status_code + ": " + message.reason_phrase);
-                    callback(false, null);
-                    return true;
-                }
-                try {
-                    const bytes = session.send_and_read_finish(response);
-                    outStream.write_bytes(bytes, null);
-                    outStream.close(null);
-                }
-                catch (e) {
-                    global.logError("Site seems to be down. Error was:");
-                    global.logError(e);
-                    callback(false, null);
-                    return true;
-                }
+        } else {
+            //Soup 3
+            session.send_and_read_async(
+                message,
+                Soup.MessagePriority.NORMAL,
+                null,
+                (session, response) => {
+                    if (message.status_code !== Soup.Status.OK) {
+                        global.log(
+                            "Error during download: response code " +
+                                message.status_code +
+                                ": " +
+                                message.reason_phrase,
+                        );
+                        callback(false, null);
+                        return true;
+                    }
+                    try {
+                        const bytes = session.send_and_read_finish(response);
+                        outStream.write_bytes(bytes, null);
+                        outStream.close(null);
+                    } catch (e) {
+                        global.logError("Site seems to be down. Error was:");
+                        global.logError(e);
+                        callback(false, null);
+                        return true;
+                    }
 
-                callback(true, localFilename);
-                return false;
-            });
+                    callback(true, localFilename);
+                    return false;
+                },
+            );
         }
     },
 
-    refresh: function(xkcdId) {
+    refresh: function (xkcdId) {
         if (this.updateInProgress) return true;
         this.updateInProgress = true;
-        
+
         let url, filename;
 
         if (this._timeoutId) {
             Mainloop.source_remove(this._timeoutId);
-            delete this._timeoutId
+            delete this._timeoutId;
         }
 
         if (xkcdId === null || xkcdId === undefined) {
-            url = 'http://www.xkcd.com/info.0.json';
-            filename = this.save_path + '/temp.json'
-            this.download_file(url, filename, this.on_json_downloaded.bind(this));
-        }
-        else {
-            url = 'http://www.xkcd.com/' + xkcdId + '/info.0.json';
-            filename = this.save_path + '/' + xkcdId + '.json';
+            url = "http://www.xkcd.com/info.0.json";
+            filename = this.save_path + "/temp.json";
+            this.download_file(
+                url,
+                filename,
+                this.on_json_downloaded.bind(this),
+            );
+        } else {
+            url = "http://www.xkcd.com/" + xkcdId + "/info.0.json";
+            filename = this.save_path + "/" + xkcdId + ".json";
             let jsonFile = Gio.file_new_for_path(filename);
             if (jsonFile.query_exists(null)) {
                 this.on_json_downloaded(true, filename, true);
-            }
-            else {
-                this.download_file(url, filename, this.on_json_downloaded.bind(this));
+            } else {
+                this.download_file(
+                    url,
+                    filename,
+                    this.on_json_downloaded.bind(this),
+                );
             }
         }
-        
+
         return true;
     },
 
-    query_tooltip: function(widget, x, y, keyboard_mode, tooltip, user_data) {
-        global.log('query tooltip');
-    },
-
-    set_tooltip: function(tip) {
-    },
-
-    on_json_downloaded: function(success, filename, cached) {
+    on_json_downloaded: function (success, filename, cached) {
         if (success) {
-            this.curXkcd = JSON.parse(Cinnamon.get_file_contents_utf8_sync(filename));
+            this.curXkcd = JSON.parse(
+                Cinnamon.get_file_contents_utf8_sync(filename),
+            );
+
+            this.altText.set_text(this.curXkcd.alt);
 
             if (this.mostRecentComic < this.curXkcd.num) {
                 this.mostRecentComic = this.curXkcd.num;
@@ -147,69 +175,64 @@ MyDesklet.prototype = {
             this._currentXkcd = this.curXkcd.num;
 
             let tempFile, jsonFile;
-            let finalFilename = this.save_path + '/' + this.curXkcd.num + '.json';
-            
+            let finalFilename =
+                this.save_path + "/" + this.curXkcd.num + ".json";
+
             if (cached !== true && filename != finalFilename) {
                 tempFile = Gio.file_new_for_path(filename);
-                
+
                 try {
                     jsonFile = Gio.file_new_for_path(finalFilename);
                     jsonFile.trash(null);
-                }
-                catch (e) {}
+                } catch (e) {}
 
                 try {
-                    tempFile.set_display_name(this.curXkcd.num + '.json', null);
-                }
-                catch (e) {}
+                    tempFile.set_display_name(this.curXkcd.num + ".json", null);
+                } catch (e) {}
             }
-            
-            this.set_tooltip(null);
-            
-            let imgFilename = this.save_path + '/' + this.curXkcd.num + '.png';
+
+            let imgFilename = this.save_path + "/" + this.curXkcd.num + ".png";
             let imgFile = Gio.file_new_for_path(imgFilename);
             if (imgFile.query_exists(null)) {
                 this.on_xkcd_downloaded(true, imgFilename, true);
+            } else {
+                this.download_file(
+                    this.curXkcd.img,
+                    imgFilename,
+                    this.on_xkcd_downloaded.bind(this),
+                );
             }
-            else {
-                this.download_file(this.curXkcd.img, imgFilename, this.on_xkcd_downloaded.bind(this));
-            }
-            
-        }
-        else {
+        } else {
             //global.log('No joy, no json');
         }
         return true;
     },
 
-    on_xkcd_downloaded: function(success, file, cached) {
-        Tweener.addTween(this._image, { opacity: 0,
-            time: this.metadata["fade-delay"],
-            transition: 'easeInSine',
-            onComplete: function() {
-                this.updateInProgress = false;
-                let pixbuf = GdkPixbuf.Pixbuf.new_from_file(file);
-                if (pixbuf != null) {
-                    this._image.set_data(pixbuf.get_pixels(),
-                        pixbuf.get_has_alpha() ?
-                        Cogl.PixelFormat.RGBA_8888 :
-                        Cogl.PixelFormat.RGB_888,
-                        pixbuf.get_width(),
-                        pixbuf.get_height(),
-                        pixbuf.get_rowstride());
-                    this._imageFrame.set_width(pixbuf.get_width())
-                    this._imageFrame.set_height(pixbuf.get_height())
-                } else {
-                    global.logError("Error reading file : " + file)
-                }
-            }.bind(this)
-        });
+    on_xkcd_downloaded: function (success, file, cached) {
+        this.updateInProgress = false;
+        let pixbuf = GdkPixbuf.Pixbuf.new_from_file(file);
+        if (pixbuf != null) {
+            this.image.set_data(
+                pixbuf.get_pixels(),
+                pixbuf.get_has_alpha()
+                    ? Cogl.PixelFormat.RGBA_8888
+                    : Cogl.PixelFormat.RGB_888,
+                pixbuf.get_width(),
+                pixbuf.get_height(),
+                pixbuf.get_rowstride(),
+            );
+            this.imageFrame.set_width(pixbuf.get_width());
+            this.imageFrame.set_height(pixbuf.get_height());
+            this.altText.set_width(pixbuf.get_width());
+        } else {
+            global.logError("Error reading file : " + file);
+        }
     },
 
-    _init: function(metadata){
-        try {            
+    _init: function (metadata) {
+        try {
             Desklet.Desklet.prototype._init.call(this, metadata);
-            this.metadata = metadata
+            this.metadata = metadata;
             this.updateInProgress = false;
             this._files = [];
             this._xkcds = [];
@@ -218,84 +241,131 @@ MyDesklet.prototype = {
 
             this.setHeader(_("xkcd"));
 
-            this._image = new Clutter.Image();
-            this._imageFrame = new Clutter.Actor({width: 0, height: 0})
-            this._imageFrame.set_content(this._image)
-            this.setContent(this._imageFrame)
-            
+            this.window = new St.BoxLayout({ vertical: true });
+
+            this.altText = new St.Label({
+                text: "",
+                style_class: "xkcd-alt-text",
+            });
+
+            this.altText.clutter_text.set_line_wrap(true);
+            this.altText.clutter_text.set_line_wrap_mode(1);
+            this.altText.clutter_text.set_ellipsize(0);
+
+            this.image = new Clutter.Image();
+            this.imageFrame = new Clutter.Actor({ width: 0, height: 0 });
+            this.imageFrame.set_content(this.image);
+
+            this.window.add_actor(this.imageFrame);
+            this.window.add_actor(this.altText);
+
+            this.setContent(this.window);
+
             this._menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this._menu.addAction(_("View latest xkcd"), function () {
-                this.refresh(null);
-            }.bind(this));
-            this._menu.addAction(_("Random xkcd"), function () {
-                let randomComicID = Math.max(1, Math.floor(Math.random() * this.mostRecentComic));
-                this.refresh(randomComicID)
-            }.bind(this));
-            this._menu.addAction(_("Open save folder"), function () {
-                Util.spawnCommandLine("xdg-open " + this.save_path);
-            }.bind(this));
+            this._menu.addAction(
+                _("View latest xkcd"),
+                function () {
+                    this.refresh(null);
+                }.bind(this),
+            );
+            this._menu.addAction(
+                _("Random xkcd"),
+                function () {
+                    let randomComicID = Math.max(
+                        1,
+                        Math.floor(Math.random() * this.mostRecentComic),
+                    );
+                    this.refresh(randomComicID);
+                }.bind(this),
+            );
+            this._menu.addAction(
+                _("Open save folder"),
+                function () {
+                    Util.spawnCommandLine("xdg-open " + this.save_path);
+                }.bind(this),
+            );
+            this._menu.addAction(
+                _("Veiw in browser"),
+                function () {
+                    Util.spawnCommandLine(
+                        "xdg-open https://www.xkcd.com/" + this.curXkcd.num,
+                    );
+                }.bind(this),
+            );
 
             let dir_path = this.metadata["directory"];
 
             // Replace special directory name if any, e.g. DIRECTORY_PICTURES/xkcd replaced by /home/username/Pictures/xkcd.
-            let special_dir_name = dir_path.substring(dir_path.indexOf("<") + 1, dir_path.indexOf(">"))
+            let special_dir_name = dir_path.substring(
+                dir_path.indexOf("<") + 1,
+                dir_path.indexOf(">"),
+            );
             if (dir_path.indexOf("<") == 0 && special_dir_name != "") {
-                let special_dir_enumvalue = eval("GLib.UserDirectory." + special_dir_name)
+                let special_dir_enumvalue = eval(
+                    "GLib.UserDirectory." + special_dir_name,
+                );
 
                 // If invalid speciale dir name, get_user_special_dir falls back to desktop folder. Here we default to ~/Pictures
-                if(special_dir_enumvalue != undefined) {
-                    let special_dir_path = GLib.get_user_special_dir(special_dir_enumvalue)
-                    dir_path = dir_path.replace("<" + special_dir_name + ">", special_dir_path);
-                }
-                else {
+                if (special_dir_enumvalue != undefined) {
+                    let special_dir_path = GLib.get_user_special_dir(
+                        special_dir_enumvalue,
+                    );
+                    dir_path = dir_path.replace(
+                        "<" + special_dir_name + ">",
+                        special_dir_path,
+                    );
+                } else {
                     dir_path = dir_path.replace(/\<.*\>/g, "~/Pictures"); // Regex capture all between "< >"
                 }
             }
 
-            this.save_path = dir_path.replace('~', GLib.get_home_dir());
+            this.save_path = dir_path.replace("~", GLib.get_home_dir());
             let saveFolder = Gio.file_new_for_path(this.save_path);
             if (!saveFolder.query_exists(null)) {
                 saveFolder.make_directory_with_parents(null);
             }
 
-            this.set_tooltip(null);
-            
-            
             let dir = Gio.file_new_for_path(this.save_path);
             if (dir.query_exists(null)) {
-                let fileEnum = dir.enumerate_children('standard::*', Gio.FileQueryInfoFlags.NONE, null);
+                let fileEnum = dir.enumerate_children(
+                    "standard::*",
+                    Gio.FileQueryInfoFlags.NONE,
+                    null,
+                );
                 let info;
                 while ((info = fileEnum.next_file(null)) != null) {
                     let fileType = info.get_file_type();
-                    if (fileType != Gio.FileType.DIRECTORY && info.get_content_type() == 'image/png') {
+                    if (
+                        fileType != Gio.FileType.DIRECTORY &&
+                        info.get_content_type() == "image/png"
+                    ) {
                         let filename = info.get_name();
-                        let xkcdId = filename.substr(0, filename.indexOf('.'));
+                        let xkcdId = filename.substr(0, filename.indexOf("."));
                         this._xkcds.push(xkcdId);
                     }
                 }
                 fileEnum.close(null);
             }
             this._xkcds.sort();
-            
+
             this.updateInProgress = false;
 
-            if (this._xkcds.length == 0)
-            {
+            if (this._xkcds.length == 0) {
                 this.refresh(null);
-            }
-            else
-            {
+            } else {
                 this.refresh(this._xkcds[this._xkcds.length - 1]);
-                this._timeoutId = Mainloop.timeout_add_seconds(5, this.refresh.bind(this, null));
-            }            
-        }
-        catch (e) {
+                this._timeoutId = Mainloop.timeout_add_seconds(
+                    5,
+                    this.refresh.bind(this, null),
+                );
+            }
+        } catch (e) {
             global.logError(e);
         }
         return true;
     },
 
-    _update: function(){
+    _update: function () {
         try {
             let idx = this._xkcds.indexOf(this._currentXkcd);
             let nextId = idx > 0 ? this._xkcds[idx - 1] : this._currentXkcd - 1;
@@ -304,25 +374,23 @@ MyDesklet.prototype = {
             }
 
             this.refresh(nextId);
-        }
-        catch (e) {
+        } catch (e) {
             global.logError(e);
         }
     },
 
-    on_desklet_clicked: function(event){  
+    on_desklet_clicked: function (event) {
         try {
             if (event.get_button() == 1) {
                 this._update();
             }
-        }
-        catch (e) {
+        } catch (e) {
             global.logError(e);
         }
-    }
-}
+    },
+};
 
-function main(metadata, desklet_id){
+function main(metadata, desklet_id) {
     let desklet = new MyDesklet(metadata);
     return desklet;
 }

--- a/xkcd@rjanja/files/xkcd@rjanja/metadata.json
+++ b/xkcd@rjanja/files/xkcd@rjanja/metadata.json
@@ -1,11 +1,11 @@
 {
- "uuid": "xkcd@rjanja",
- "name": "xkcd comics viewer",
- "description": "A viewer for today's xkcd comic",
- "minimum-decoration": 1,
- "directory":"<DIRECTORY_PICTURES>/xkcd",
- "delay": 5,
- "quality": 2,
- "fade-delay": 0.3
+    "uuid": "xkcd@rjanja",
+    "name": "xkcd comics viewer",
+    "description": "A viewer for today's xkcd comic",
+    "minimum-decoration": 1,
+    "directory": "<DIRECTORY_PICTURES>/xkcd",
+    "delay": 5,
+    "quality": 2,
+    "author": "rjanja",
+    "last-edited": 1720817553
 }
-

--- a/xkcd@rjanja/files/xkcd@rjanja/stylesheet.css
+++ b/xkcd@rjanja/files/xkcd@rjanja/stylesheet.css
@@ -1,6 +1,13 @@
 .xkcd-box {
     padding: 5px;
-    border: 2px solid #96A8C8;
+    border: 2px solid #96a8c8;
     background-color: rgba(150, 168, 200, 0.7);
+    border-radius: 5px;
+}
+.xkcd-alt-text {
+    font-size: 16px;
+    padding: 5px;
+    color: white;
+    background-color: rgba(0, 0, 0, 0.5);
     border-radius: 5px;
 }


### PR DESCRIPTION
- Added XKCD alt text under the image, but now with text wrapping and no more stretchy images!!
- Added "View in browser" to the popup menu
- Removed all references to the Tweener library because it wasn't functioning

**Note**: you *may* need to restart Cinnamon through the Melange debugger once you update the desklet, because the CSS won't update otherwise. Once you do that, it should be fine.