### PR TITLE
notes@schorschii: added word wrapping to notes

### DIFF
--- a/notes@schorschii/files/notes@schorschii/desklet.js
+++ b/notes@schorschii/files/notes@schorschii/desklet.js
@@ -80,6 +80,8 @@ MyDesklet.prototype = {
 		this.settings.bindProperty(Settings.BindingDirection.IN, "bg-color", "customBgColor", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "file", "file", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "edit-cmd", "editCmd", this.on_setting_changed);
+                this.settings.bindProperty(Settings.BindingDirection.IN, "wrap-scale-size", "wrapScaleSize", this.on_setting_changed); 
+		this.settings.bindProperty(Settings.BindingDirection.IN, "enable-word-wrap", "enableWordWrap", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "note-taking-method", "noteTakingMethod", this.on_setting_changed);
 		this.settings.bindProperty(Settings.BindingDirection.IN, "note-text", "noteText", this.on_setting_changed);
 
@@ -261,11 +263,40 @@ MyDesklet.prototype = {
 			//Main.notifyError("Complete Refresh Done", " "); // debug
 		}
 
+        let displayedText;
+        if (this.enableWordWrap) {
+            //word-wrap: as notetext is a label, it cannot be word-wrapped automatically, so 
+            //manual word-wrapping is needed. This one estimates width (number of chars) 
+            let width = (this.desklet_width / this.sizeFont * this.wrapScaleSize) | 0;
+            let arr = this.notecontent.split("\n");
+            for (let i = 0; i < arr.length; i++) {
+                if (arr[i].length > width)
+                  arr[i] = this.stringDivider(arr[i], width, "\n");
+            }
+            displayedText = arr.join("\n");
+        } else {
+            displayedText = this.notecontent;
+        }
+               
 		// refresh text
-		this.notetext.set_text(this.notecontent);
+		this.notetext.set_text(displayedText);
 
 		//Main.notifyError("Text Refresh Done", " "); // debug
 	},
+
+    stringDivider: function(str, width, spaceReplacer) {
+        if (str.length>width) {
+            let p=width
+            for (;p>0 && str[p]!=' ' && str[p]!='\n' ;p--) {
+            }
+            if (p>0) {
+                let left = str.substring(0, p);
+                let right = str.substring(p+1);
+                return left + spaceReplacer + this.stringDivider(right, width, spaceReplacer);
+            }
+        }
+        return str;
+    },
 
 	refreshDecoration: function() {
 		// desklet label (header)

--- a/notes@schorschii/files/notes@schorschii/metadata.json
+++ b/notes@schorschii/files/notes@schorschii/metadata.json
@@ -2,6 +2,6 @@
     "max-instances": "10",
     "description": "A desklet to display notes including various themes.",
     "name": "Note",
-    "version": "2.5",
+    "version": "2.6",
     "uuid": "notes@schorschii"
 }

--- a/notes@schorschii/files/notes@schorschii/po/ca.po
+++ b/notes@schorschii/files/notes@schorschii/po/ca.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2024-10-01 03:13+0200\n"
 "Last-Translator: Daniel <d3vf4n@tutanota.com>\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Actualitza"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Feu clic aquí per editar-ho."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Llibreta"
 
@@ -263,6 +263,15 @@ msgstr "Cap"
 msgid "Select the background graphic you would like to use."
 msgstr "Seleccioneu el gràfic de fons que voleu utilitzar."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Color del text"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr "Color del fons"
@@ -270,6 +279,10 @@ msgstr "Color del fons"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Estableix el color del fons de la nota."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/da.po
+++ b/notes@schorschii/files/notes@schorschii/po/da.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2023-12-08 07:45+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Dansk-gruppen <dansk@dansk-gruppen.dk>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Opdatér"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Klik her for at redigere."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Notesblok"
 
@@ -261,6 +261,15 @@ msgstr "Ingen"
 msgid "Select the background graphic you would like to use."
 msgstr "Vælg den baggrundsgrafik, du ønsker at bruge."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Tekstfarve"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr "Baggrundsfarve"
@@ -268,6 +277,10 @@ msgstr "Baggrundsfarve"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Angiv baggrundsfarven for dette skrivebordsprogram."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/de.po
+++ b/notes@schorschii/files/notes@schorschii/po/de.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2023-04-04 15:06+0200\n"
 "Last-Translator: Georg Sieber\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Klicken Sie hier zum Bearbeiten."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Notizblock"
 
@@ -277,6 +277,10 @@ msgstr "Hintergrundfarbe"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Wählen Sie die Hintergrundfarbe für dieses Desklet."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/es.po
+++ b/notes@schorschii/files/notes@schorschii/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2025-04-14 10:00-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Actualizar"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -35,7 +35,7 @@ msgstr ""
 "\n"
 "Haga clic aquí para editarlo."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Bloc de notas"
 
@@ -279,6 +279,10 @@ msgstr "Color de fondo"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Establece el color de fondo de este desklet."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/fi.po
+++ b/notes@schorschii/files/notes@schorschii/po/fi.po
@@ -7,22 +7,22 @@ msgstr ""
 "Project-Id-Version: notes@schorschii 2.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: \n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Virkistä"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -34,7 +34,7 @@ msgstr ""
 "\n"
 "Paina tästä ja muokkaa."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Muistilappu"
 
@@ -261,6 +261,15 @@ msgstr "Ei mitään"
 msgid "Select the background graphic you would like to use."
 msgstr "Valitse taustagrafiikka, jota haluat käyttää."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Tekstin väri"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr "Taustaväri"
@@ -268,6 +277,10 @@ msgstr "Taustaväri"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Aseta sovelman taustaväri."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/fr.po
+++ b/notes@schorschii/files/notes@schorschii/po/fr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2020-01-24 23:40+0100\n"
 "Last-Translator: Anonymous <ano@nymo.us>\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr ""
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Cliquez ici pour modifier."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Bloc Note"
 
@@ -60,7 +60,7 @@ msgstr "Visuel"
 msgid "Custom desklet label (only visible if decorations are enabled)"
 msgstr ""
 "Étiquette de desklet personnalisée (visible seulement si décorations "
-"activées)" 
+"activées)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"
@@ -262,6 +262,15 @@ msgstr ""
 msgid "Select the background graphic you would like to use."
 msgstr "Sélectionnez le fond graphique que vous souhaitez utiliser."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Couleur du texte"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr ""
@@ -269,6 +278,10 @@ msgstr ""
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Changer la couleur du texte de ce desklet."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/hu.po
+++ b/notes@schorschii/files/notes@schorschii/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2024-10-02 14:46+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Frissítés"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -34,7 +34,7 @@ msgstr ""
 "\n"
 "Kattintson ide a szerkesztéshez."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Jegyzettömb"
 
@@ -262,6 +262,15 @@ msgstr "Nincs"
 msgid "Select the background graphic you would like to use."
 msgstr "Válasszon ki egy háttérgrafikát a használathoz."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Szövegszín"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr "Háttérszín"
@@ -269,6 +278,10 @@ msgstr "Háttérszín"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Asztalkalmazás szövegszínének beállítása."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/it.po
+++ b/notes@schorschii/files/notes@schorschii/po/it.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2023-12-12 18:46+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Clicca qui per modificare."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Blocco note"
 
@@ -262,6 +262,15 @@ msgstr "Nessuno"
 msgid "Select the background graphic you would like to use."
 msgstr "Seleziona l'immagine di sfondo che desideri utilizzare."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Colore del testo"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr "Colore di sfondo"
@@ -269,6 +278,10 @@ msgstr "Colore di sfondo"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Imposta il colore di sfondo di questo desklet."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/nl.po
+++ b/notes@schorschii/files/notes@schorschii/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2024-11-28 15:27+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Vernieuwen"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 " \n"
 "Klik hier om te bewerken."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Kladblok"
 
@@ -263,6 +263,15 @@ msgstr "Geen"
 msgid "Select the background graphic you would like to use."
 msgstr "Selecteer de achtergrondafbeelding die u wilt gebruiken."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Tekstkleur"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr "Achtergrondkleur"
@@ -270,6 +279,10 @@ msgstr "Achtergrondkleur"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Stel de achtergrondkleur van deze desklet in."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/notes@schorschii.pot
+++ b/notes@schorschii/files/notes@schorschii/po/notes@schorschii.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: notes@schorschii 2.4\n"
+"Project-Id-Version: notes@schorschii 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr ""
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -29,7 +29,7 @@ msgid ""
 "Click here to edit."
 msgstr ""
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr ""
 
@@ -270,6 +270,10 @@ msgstr ""
 
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
+msgstr ""
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
 msgstr ""
 
 #. settings-schema.json->hide-decorations->description

--- a/notes@schorschii/files/notes@schorschii/po/pt.po
+++ b/notes@schorschii/files/notes@schorschii/po/pt.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: notes@schorschii 2.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2024-09-28 15:39-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Atualizar"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -33,7 +33,7 @@ msgstr ""
 "\n"
 "Clique aqui para editar."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Bloco de notas"
 
@@ -262,6 +262,15 @@ msgstr "Nenhum"
 msgid "Select the background graphic you would like to use."
 msgstr "Selecione o gráfico de fundo que gostaria de utilizar."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Cor do texto"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr "Cor de fundo"
@@ -269,6 +278,10 @@ msgstr "Cor de fundo"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Defina a cor de fundo deste desklet."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/pt_BR.po
+++ b/notes@schorschii/files/notes@schorschii/po/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2021-09-28 22:12-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr ""
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -35,7 +35,7 @@ msgstr ""
 "\n"
 "Clique aqui para editar."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Bloco de notas"
 
@@ -266,6 +266,15 @@ msgstr "Nenhum"
 msgid "Select the background graphic you would like to use."
 msgstr "Selecione a cor da anotação de sua preferência."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Cor do texto"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr ""
@@ -274,6 +283,10 @@ msgstr ""
 #, fuzzy
 msgid "Set the background color of this desklet."
 msgstr "Defina a cor do texto desse desklet."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/ro.po
+++ b/notes@schorschii/files/notes@schorschii/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2023-04-04 15:06+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
 "20)) ? 1 : 2;\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr "Reîmprospătare"
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -35,7 +35,7 @@ msgstr ""
 "\n"
 "Fă clic aici pentru a edita."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Blocul de notițe"
 
@@ -60,7 +60,9 @@ msgstr "Vizual"
 
 #. settings-schema.json->label-section->title
 msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr "Etichetă personalizată pentru desklet (vizibilă numai dacă sunt activate decorațiile)"
+msgstr ""
+"Etichetă personalizată pentru desklet (vizibilă numai dacă sunt activate "
+"decorațiile)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"
@@ -262,6 +264,15 @@ msgstr "Nici unul"
 msgid "Select the background graphic you would like to use."
 msgstr "Selectează grafica de fundal pe care dorești să o utilizezi."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Culoarea textului"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr "Culoarea de fundal"
@@ -269,6 +280,10 @@ msgstr "Culoarea de fundal"
 #. settings-schema.json->bg-color->tooltip
 msgid "Set the background color of this desklet."
 msgstr "Setează culoarea de fundal a acestui desklet."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/ru.po
+++ b/notes@schorschii/files/notes@schorschii/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2021-03-14 14:38+0100\n"
 "Last-Translator: Alex Savvin <savvin@mail.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr ""
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -34,7 +34,7 @@ msgstr ""
 "\n"
 "Щёлкните здесь для редактирования."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Блокнот"
 
@@ -261,6 +261,15 @@ msgstr "–"
 msgid "Select the background graphic you would like to use."
 msgstr "Выберите желаемый фон."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Цвет текста"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr ""
@@ -269,6 +278,10 @@ msgstr ""
 #, fuzzy
 msgid "Set the background color of this desklet."
 msgstr "Настройка цвета текста дисклета."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/sv.po
+++ b/notes@schorschii/files/notes@schorschii/po/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: notes@schorschii\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2019-02-27 06:19+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -22,11 +22,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr ""
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -38,7 +38,7 @@ msgstr ""
 "\n"
 "Klicka här för att redigera."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Notepad"
 
@@ -63,8 +63,7 @@ msgstr "Visuellt"
 
 #. settings-schema.json->label-section->title
 msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Anpassad programetikett (synlig endast om dekorationer är aktiverade)."
+msgstr "Anpassad programetikett (synlig endast om dekorationer är aktiverade)."
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"
@@ -266,6 +265,15 @@ msgstr ""
 msgid "Select the background graphic you would like to use."
 msgstr "Välj den bakgrundsgrafik du vill använda."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Textfärg"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr ""
@@ -274,6 +282,10 @@ msgstr ""
 #, fuzzy
 msgid "Set the background color of this desklet."
 msgstr "Ange textfärg för anteckningar."
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/po/tr.po
+++ b/notes@schorschii/files/notes@schorschii/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-09-28 12:45-0400\n"
+"POT-Creation-Date: 2025-05-03 11:37-0400\n"
 "PO-Revision-Date: 2018-11-27 15:10+0300\n"
 "Last-Translator: Gökhan GÖKKAYA <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye <gokhanlnx@gmail.com>\n"
@@ -22,11 +22,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: desklet.js\n"
 "X-Poedit-SearchPath-1: settings-schema.json\n"
 
-#. desklet.js:133
+#. desklet.js:138
 msgid "Refresh"
 msgstr ""
 
-#. desklet.js:146
+#. desklet.js:151
 msgid ""
 "Can't read text file.\n"
 "Select a file in settings.\n"
@@ -38,7 +38,7 @@ msgstr ""
 "\n"
 "Düzenlemek için buraya tıklayınız."
 
-#. desklet.js:272
+#. desklet.js:289
 msgid "Notepad"
 msgstr "Not defteri"
 
@@ -63,8 +63,7 @@ msgstr "Görsel"
 
 #. settings-schema.json->label-section->title
 msgid "Custom desklet label (only visible if decorations are enabled)"
-msgstr ""
-"Masaüstü uygulamacığı özel etiketi (sadece süslemeler etkinse görünür)"
+msgstr "Masaüstü uygulamacığı özel etiketi (sadece süslemeler etkinse görünür)"
 
 #. settings-schema.json->note-taking-method->description
 msgid "Note Taking Method"
@@ -266,6 +265,15 @@ msgstr ""
 msgid "Select the background graphic you would like to use."
 msgstr "Kullanmak istediğiniz arkaplan grafiğini seçin."
 
+#. settings-schema.json->text-shadow->description
+msgid "Text shadow"
+msgstr ""
+
+#. settings-schema.json->text-shadow-color->description
+#, fuzzy
+msgid "Text shadow color"
+msgstr "Metin rengi"
+
 #. settings-schema.json->bg-color->description
 msgid "Background color"
 msgstr ""
@@ -274,6 +282,10 @@ msgstr ""
 #, fuzzy
 msgid "Set the background color of this desklet."
 msgstr "Bu masaüstü uygulamacığının metin rengini ayarla"
+
+#. settings-schema.json->enable-word-wrap->description
+msgid "Enable word wrap"
+msgstr ""
 
 #. settings-schema.json->hide-decorations->description
 msgid "Hide decorations"

--- a/notes@schorschii/files/notes@schorschii/settings-schema.json
+++ b/notes@schorschii/files/notes@schorschii/settings-schema.json
@@ -45,7 +45,6 @@
                 "style",
                 "scale-size",
                 "enable-word-wrap",
-                "wrap-scale-size",
                 "hide-decorations",
                 "text-shadow",
                 "text-shadow-color",
@@ -215,16 +214,6 @@
         "units": "scale factor",
         "description": "Desklet size",
         "tooltip": "Increase or decrease the size of this desklet using this scale factor."
-    },
-    "wrap-scale-size": {
-        "type": "spinbutton",
-        "default": 1.2,
-        "min": 1.0,
-        "max": 2.0,
-        "step": 0.1,
-        "units": "scale factor",
-        "description": "Word-wrap: font scale factor",
-        "tooltip": "Increase or decrease the size to better word-wrap using this scale factor."
     },
     "use-custom-label": {
         "type": "checkbox",

--- a/notes@schorschii/files/notes@schorschii/settings-schema.json
+++ b/notes@schorschii/files/notes@schorschii/settings-schema.json
@@ -44,6 +44,8 @@
             "keys": [
                 "style",
                 "scale-size",
+                "enable-word-wrap",
+                "wrap-scale-size",
                 "hide-decorations",
                 "text-shadow",
                 "text-shadow-color",
@@ -163,6 +165,11 @@
         "tooltip": "Set the background color of this desklet.",
         "dependency": "style=none"
     },
+    "enable-word-wrap": {
+        "type": "switch",
+        "description": "Enable word wrap",
+        "default": true
+    },
     "hide-decorations": {
         "type": "switch",
         "description": "Hide decorations",
@@ -208,6 +215,16 @@
         "units": "scale factor",
         "description": "Desklet size",
         "tooltip": "Increase or decrease the size of this desklet using this scale factor."
+    },
+    "wrap-scale-size": {
+        "type": "spinbutton",
+        "default": 1.2,
+        "min": 1.0,
+        "max": 2.0,
+        "step": 0.1,
+        "units": "scale factor",
+        "description": "Word-wrap: font scale factor",
+        "tooltip": "Increase or decrease the size to better word-wrap using this scale factor."
     },
     "use-custom-label": {
         "type": "checkbox",


### PR DESCRIPTION
Updates notes@schorschii by @schorschii to add word wrapping.

Attempts to integrate code from https://github.com/aizma/Note-by-schorschii---word-wrap/ into current version of notes.
I opened this issue about the idea then decided to do a PR since i had the files already: https://github.com/linuxmint/cinnamon-spices-desklets/issues/1467

It isn't a perfect solution and I don't really know what I'm doing in javascript, but it does seem to work on my end.