### PR TITLE
yfquotes@thegli: fix quote styling when symbol was not capitalized

### DIFF
--- a/yfquotes@thegli/CHANGELOG.md
+++ b/yfquotes@thegli/CHANGELOG.md
@@ -1,3 +1,16 @@
+### 0.16.1 - July 3, 2025
+
+Features:
+
+- update default User-Agent header to latest Firefox ESR release
+- update Dutch translation (courtesy of [qadzek](https://github.com/qadzek))
+- update Hungarian translation (courtesy of [bossbob88](https://github.com/bossbob88))
+- update Spanish translation (courtesy of [haggen88](https://github.com/haggen88))
+
+Bugfixes:
+
+- apply individual quote style independent of capitalization of the symbol
+
 ### 0.16.0 - May 11, 2025
 
 Features:

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -154,7 +154,7 @@ YahooFinanceQuoteUtils.prototype = {
             .split("\n")
             .map((line) => line.trim())
             .filter((line) => line !== "")
-            .map((line) => line.split(";")[0])
+            .map((line) => line.split(";")[0].toUpperCase())
             .join();
     },
 
@@ -187,7 +187,7 @@ YahooFinanceQuoteUtils.prototype = {
     // data structure for quote customization parameters
     buildSymbolCustomization: function(symbol, customAttributes) {
         return {
-            symbol,
+            symbol: symbol.toUpperCase(),
             name: customAttributes.has("name") ? customAttributes.get("name") : null,
             style: customAttributes.has("style") ? customAttributes.get("style") : "normal",
             weight: customAttributes.has("weight") ? customAttributes.get("weight") : "normal",

--- a/yfquotes@thegli/files/yfquotes@thegli/metadata.json
+++ b/yfquotes@thegli/files/yfquotes@thegli/metadata.json
@@ -3,6 +3,6 @@
     "name": "Yahoo Finance Quotes",
     "prevent-decorations": true,
     "max-instances": "10",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "uuid": "yfquotes@thegli"
 }

--- a/yfquotes@thegli/files/yfquotes@thegli/settings-schema.json
+++ b/yfquotes@thegli/files/yfquotes@thegli/settings-schema.json
@@ -477,7 +477,7 @@
     },
     "customUserAgent": {
         "type": "entry",
-        "default": "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+        "default": "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
         "description": "Custom User-Agent header",
         "tooltip": "Value for User-Agent header to send with all API requests",
         "dependency": "sendCustomUserAgent"


### PR DESCRIPTION
- apply individual quote style independent of capitalization of the symbol (fixes #1495)
- update default User-Agent header to latest Firefox ESR release

