### PR TITLE
 systemUptime@KopfDesDaemons: more uptime info

### DIFF
--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/desklet.js
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/desklet.js
@@ -45,7 +45,7 @@ class MyDesklet extends Desklet.Desklet {
         const uptimeRow = this.createRow([this.uptimeLabel, this.uptimeValue]);
 
         // Create labels for startup time
-        this.startTimeLabel = this.createLabel(_("System start time:") + " ", this.colorLabel);
+        this.startTimeLabel = this.createLabel(_("Start time:") + " ", this.colorLabel);
         this.startupValue = this.createLabel(_("Loading..."));
 
         const startupRow = this.createRow([this.startTimeLabel, this.startupValue]);
@@ -97,10 +97,11 @@ class MyDesklet extends Desklet.Desklet {
             if (!result || !out) throw new Error("Could not get system uptime.");
 
             const uptimeInSeconds = parseFloat(out.toString().trim());
-            const hours = Math.floor(uptimeInSeconds / 3600);
-            const minutes = Math.floor((uptimeInSeconds % 3600) / 60);
+            const days = Math.floor(uptimeInSeconds / 86400);
+            const hours = Math.floor((uptimeInSeconds % 86400) / 3600);
+            const minutes = Math.floor(((uptimeInSeconds % 86400) % 3600) / 60);
 
-            this.uptimeValue.set_text(`${hours} ${_("hours")} ${minutes} ${_("minutes")}`);
+            this.uptimeValue.set_text(`${days} ${_("days")}, ${hours} ${_("hrs")} ${minutes} ${_("min")}`);
         } catch (error) {
             this.uptimeValue.set_text("Error");
             global.logError(`${UUID}: ${error.message}`);
@@ -115,7 +116,9 @@ class MyDesklet extends Desklet.Desklet {
             const [result, out] = GLib.spawn_command_line_sync("uptime -s");
             if (!result || !out) throw new Error("Could not get system startup time.");
 
-            this.startupValue.set_text(out.toString().split(" ")[1].trim());
+            let dateTime = out.toString().split(" ");
+            let date = dateTime[0].split("-");
+            this.startupValue.set_text(date[2]+"."+date[1]+"."+date[0]+" "+dateTime[1].trim());
         } catch (error) {
             this.startupValue.set_text("Error");
             global.logError(`${UUID}: ${error.message}`);

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/metadata.json
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/metadata.json
@@ -3,5 +3,7 @@
     "name": "System Uptime",
     "description": "Displays the current system uptime.",
     "version": "1.0",
-    "max-instances": "50"
+    "max-instances": "50",
+    "author": "KopfDesDaemons",
+    "last-edited": 1744390204
 }

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/ca.po
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/ca.po
@@ -32,15 +32,19 @@ msgid "Loading..."
 msgstr "S'està carregant..."
 
 #. desklet.js:48
-msgid "System start time:"
-msgstr "Hora d'inici del sistema:"
+msgid "Start time:"
+msgstr "Hora d'inici:"
 
 #. desklet.js:91
-msgid "hours"
+msgid "days"
+msgstr "dies"
+
+#. desklet.js:91
+msgid "hrs"
 msgstr "hores"
 
 #. desklet.js:91
-msgid "minutes"
+msgid "min"
 msgstr "minuts"
 
 #. metadata.json->description

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/de.po
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/de.po
@@ -32,16 +32,20 @@ msgid "Loading..."
 msgstr "Lade..."
 
 #. desklet.js:48
-msgid "System start time:"
-msgstr "Systemstartzeitpunkt:"
+msgid "Start time:"
+msgstr "Startzeitpunkt:"
 
 #. desklet.js:91
-msgid "hours"
-msgstr "Stunden"
+msgid "days"
+msgstr "Tage"
 
 #. desklet.js:91
-msgid "minutes"
-msgstr "Minuten"
+msgid "hrs"
+msgstr "Std."
+
+#. desklet.js:91
+msgid "min"
+msgstr "Min."
 
 #. metadata.json->description
 msgid "Displays the current system uptime."

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/es.po
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/es.po
@@ -31,15 +31,19 @@ msgid "Loading..."
 msgstr "Cargando…"
 
 #. desklet.js:48
-msgid "System start time:"
-msgstr "Hora de inicio del sistema:"
+msgid "Start time:"
+msgstr "Hora de inicio:"
 
 #. desklet.js:91
-msgid "hours"
+msgid "days"
+msgstr "días"
+
+#. desklet.js:91
+msgid "hrs"
 msgstr "horas"
 
 #. desklet.js:91
-msgid "minutes"
+msgid "min"
 msgstr "minutos"
 
 #. metadata.json->description

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/hu.po
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/hu.po
@@ -32,15 +32,19 @@ msgid "Loading..."
 msgstr "Betöltés..."
 
 #. desklet.js:48
-msgid "System start time:"
-msgstr "A rendszer indulási ideje:"
+msgid "Start time:"
+msgstr "Indítási idő:"
 
 #. desklet.js:91
-msgid "hours"
+msgid "days"
+msgstr "napok"
+
+#. desklet.js:91
+msgid "hrs"
 msgstr "óra"
 
 #. desklet.js:91
-msgid "minutes"
+msgid "min"
 msgstr "perc"
 
 #. metadata.json->description

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/nl.po
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/nl.po
@@ -30,15 +30,19 @@ msgid "Loading..."
 msgstr "Laden..."
 
 #. desklet.js:48
-msgid "System start time:"
-msgstr "Systeem opstarttijd:"
+msgid "Start time:"
+msgstr "Opstarttijd:"
 
 #. desklet.js:91
-msgid "hours"
+msgid "days"
+msgstr "dagen"
+
+#. desklet.js:91
+msgid "hrs"
 msgstr "uren"
 
 #. desklet.js:91
-msgid "minutes"
+msgid "min"
 msgstr "minuten"
 
 #. metadata.json->description

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/systemUptime@KopfDesDaemons.pot
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/po/systemUptime@KopfDesDaemons.pot
@@ -31,15 +31,19 @@ msgid "Loading..."
 msgstr ""
 
 #. desklet.js:48
-msgid "System start time:"
+msgid "Start time:"
 msgstr ""
 
 #. desklet.js:91
-msgid "hours"
+msgid "days"
 msgstr ""
 
 #. desklet.js:91
-msgid "minutes"
+msgid "hrs"
+msgstr ""
+
+#. desklet.js:91
+msgid "min"
 msgstr ""
 
 #. metadata.json->description


### PR DESCRIPTION
For long running systems, it is useful to display the exact startup date and the uptime in days, hours, minutes. To make sure the desklet width does not get too big, I renamed "System start time" to "Start time". This also better aligns with the "Uptime" label, since it is not called "System uptime" too.

What do you think @KopfdesDaemons ?