### PR TITLE
 system-monitor-graph@rcassani: network monitoring adjustments

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
@@ -293,8 +293,8 @@ SystemMonitorGraph.prototype = {
               let down_speed_formatted = this.format_network_speed(this.net_down_speed);
               let up_speed_formatted = this.format_network_speed(this.net_up_speed);
               
-              text2 = "↓ " + down_speed_formatted;
-              text3 = "↑ " + up_speed_formatted;
+              text2 = "";
+              text3 = "↓ " + down_speed_formatted + "  ↑ " + up_speed_formatted;
               break;
         }
 
@@ -389,19 +389,11 @@ SystemMonitorGraph.prototype = {
             Math.round((2.5 * unit_size) - this.text2.get_height())
         );
         this.text3.set_text(text3);
-        if (this.type !== "network") {
-            this.text3.style = "font-size: " + text3_size + "px;"
-                             + "color: " + this.text_color + ";";
-            this.text3.set_position(
-                Math.round((21 * unit_size) - this.text3.get_width()),
-                Math.round((2.5 * unit_size) - this.text3.get_height()));
-        } else {
-            this.text3.style = "font-size: " + text2_size + "px;"
-                             + "color: " + this.text_color + ";";
-            this.text3.set_position(
-                Math.round(this.text1.get_width() + (9 * unit_size)),
-                Math.round((2.5 * unit_size) - this.text3.get_height()));
-        }
+        this.text3.style = "font-size: " + text3_size + "px;"
+                         + "color: " + this.text_color + ";";
+        this.text3.set_position(
+            Math.round((21 * unit_size) - this.text3.get_width()),
+            Math.round((2.5 * unit_size) - this.text3.get_height()));
 
 
         // update canvas
@@ -522,15 +514,34 @@ SystemMonitorGraph.prototype = {
     format_network_speed: function(speed_bytes_per_sec) {
         // Enhanced error handling for speed formatting
         if (!speed_bytes_per_sec || isNaN(speed_bytes_per_sec) || !isFinite(speed_bytes_per_sec) || speed_bytes_per_sec < 0) {
-            return "0 " + _("B") + "/s";
+            if (this.data_prefix_network == 2) {
+                return "0 " + _("b") + "/s";
+            } else {
+                return "0 " + _("B") + "/s";
+            }
         }
         
         // Convert bytes per second to appropriate units
         let speed = speed_bytes_per_sec;
         let unit = "";
         
-        if (this.data_prefix_network == 1) {
-            // Decimal prefix (1000-based)
+        if (this.data_prefix_network == 2) {
+            // Decimal prefix (1000-based) bit
+            speed = speed * 8;
+            if (speed >= 1000000000) {
+                speed = speed / 1000000000;
+                unit = _("Gb") + "/s";
+            } else if (speed >= 1000000) {
+                speed = speed / 1000000;
+                unit = _("Mb") + "/s";
+            } else if (speed >= 1000) {
+                speed = speed / 1000;
+                unit = _("Kb") + "/s";
+            } else {
+                unit = _("b") + "/s";
+            }
+        } else if (this.data_prefix_network == 1) {
+            // Decimal prefix (1000-based) bytes
             if (speed >= 1000000000) {
                 speed = speed / 1000000000;
                 unit = _("GB") + "/s";
@@ -544,7 +555,7 @@ SystemMonitorGraph.prototype = {
                 unit = _("B") + "/s";
             }
         } else {
-            // Binary prefix (1024-based)
+            // Binary prefix (1024-based) bytes
             if (speed >= 1073741824) { // 1024^3
                 speed = speed / 1073741824;
                 unit = _("GiB") + "/s";

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -4,7 +4,5 @@
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
     "version": "2.0",
-    "prevent-decorations": true,
-    "author": "rcassani",
-    "last-edited": 1751754412
+    "prevent-decorations": true
 }

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -4,5 +4,7 @@
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
     "version": "2.0",
-    "prevent-decorations": true
+    "prevent-decorations": true,
+    "author": "rcassani",
+    "last-edited": 1751754412
 }

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/ca.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2023-08-04 22:51+0200\n"
 "Last-Translator: Daniel <d3vf4n@tutanota.com>\n"
 "Language-Team: \n"
@@ -24,11 +24,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -59,25 +59,41 @@ msgstr "Memòria de la GPU"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -152,12 +168,17 @@ msgstr "Prefix de la unitat de mesura del sistema de fitxers."
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Prefix binari o de l'IEC (1GiB = 1024³ octets)"
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Prefix decimal (1 GB = 1000³ octets)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Prefix decimal (1 GB = 1000³ octets)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/da.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2023-12-08 07:51+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -24,11 +24,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -59,25 +59,41 @@ msgstr "GPU-hukommelse"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -150,12 +166,17 @@ msgstr "Enhedspræfiks for filsystemstørrelse."
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Binært præfiks eller IEC (1 GiB = 1024³ bytes)"
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Decimalpræfiks (1 GB = 1000³ bytes)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Decimalpræfiks (1 GB = 1000³ bytes)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/de.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/de.po
@@ -164,7 +164,7 @@ msgstr "Einheiten-Präfix für Swap-Größe."
 #. settings-schema.json->network-interface->description
 #, fuzzy
 msgid "Network interface to monitor"
-msgstr "Wählen Sie die anzuzeigende GPU-Variable."
+msgstr "Zu überwachendes Netzwerkinterface"
 
 #. settings-schema.json->network-interface->tooltip
 msgid ""
@@ -348,12 +348,12 @@ msgstr "GPU-Linienfarbe"
 #. settings-schema.json->line-color-network-down->description
 #, fuzzy
 msgid "Line color Network Download"
-msgstr "Swap-Linienfarbe"
+msgstr "Netzwerk-Download-Linienfarbe"
 
 #. settings-schema.json->line-color-network-up->description
 #, fuzzy
 msgid "Line color Network Upload"
-msgstr "Swap-Linienfarbe"
+msgstr "Netzwerk-Upload-Linienfarbe"
 
 #. settings-schema.json->midline-color->description
 msgid "Grid color"

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/de.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2022-04-17 18:13+0100\n"
 "Last-Translator: Georg Sieber\n"
 "Language-Team: \n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -57,25 +57,41 @@ msgstr "GPU-Speicher"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -148,12 +164,17 @@ msgstr "Einheiten-Präfix für Dateisystem-Größe."
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Binär bzw. IEC (1 GiB = 1024³ Bytes)"
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Dezimal (1 GB = 1000³ Bytes)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Dezimal (1 GB = 1000³ Bytes)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/es.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2025-07-05 18:24-0400\n"
 "Last-Translator: Daniel <d3vf4n@tutanota.com>\n"
 "Language-Team: \n"
@@ -24,11 +24,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -59,23 +59,39 @@ msgstr "Memoria de GPU"
 msgid "Network"
 msgstr "Red"
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 msgid "B"
 msgstr "B"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr "MB"
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr "KB"
 
-#. desklet.js:553
+#. desklet.js:564
 msgid "MiB"
 msgstr "MiB"
 
-#. desklet.js:556
+#. desklet.js:567
 msgid "KiB"
 msgstr "KiB"
 
@@ -148,11 +164,18 @@ msgid "Unit prefix for Filesystem size."
 msgstr "Prefijo de la unidad de medida del sistema de archivos."
 
 #. settings-schema.json->data-prefix-network->options
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+#, fuzzy
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Prefijo binario o del IEC (1 KiB = 1024 bytes)"
 
 #. settings-schema.json->data-prefix-network->options
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+#, fuzzy
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Prefijo decimal (1 KB = 1000 bytes)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Prefijo decimal (1 KB = 1000 bytes)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/fi.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2024-11-09 13:32+0200\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -24,11 +24,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -59,25 +59,41 @@ msgstr "GPU Muisti"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -152,12 +168,17 @@ msgstr "Lukemat kiintolevyn kokoa varten."
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Binäärinen lukema tai IEC (1 GiB = 1024³ bytes)"
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Desimaalinen lukema (1 GB = 1000³ bytes)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Desimaalinen lukema (1 GB = 1000³ bytes)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/hu.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2023-12-13 12:42+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -24,11 +24,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -59,25 +59,41 @@ msgstr "GPU memória"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -150,12 +166,17 @@ msgstr "A fájlrendszer méretének egység előtagja."
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Bináris előtag vagy IEC (1 GiB = 1024³ bájt)"
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Tizedes előtag (1 GB = 1000³ bájt)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Tizedes előtag (1 GB = 1000³ bájt)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/it.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2023-12-12 18:57+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -24,11 +24,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -59,25 +59,41 @@ msgstr "Memoria GPU"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -150,12 +166,17 @@ msgstr "Prefisso dell'unità per la dimensione del file system."
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Prefisso binario o IEC (1 GiB = 1024³ byte)"
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Prefisso decimale (1 GB = 1000³ byte)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Prefisso decimale (1 GB = 1000³ byte)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/nl.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2024-04-19 14:32+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -57,25 +57,41 @@ msgstr "GPU Geheugen"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -148,12 +164,17 @@ msgstr "Eenheid voorvoegsel voor Bestandssysteemgrootte."
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Binair voorvoegsel of IEC (1 GiB = 1024³ bytes)"
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Decimaal voorvoegsel (1 GB = 1000³ bytes)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Decimaal voorvoegsel (1 GB = 1000³ bytes)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/pt_BR.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2021-11-29 15:20-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -24,11 +24,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -59,25 +59,41 @@ msgstr "Memória da GPU"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -149,11 +165,15 @@ msgid "Unit prefix for Filesystem size."
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->options
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->options
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr ""
+
+#. settings-schema.json->data-prefix-network->options
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/ro.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: 2022-04-17 23:21+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -24,11 +24,11 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr "GB"
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr "GiB"
 
@@ -59,25 +59,41 @@ msgstr "Memorie GPU"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 #, fuzzy
 msgid "B"
 msgstr "GB"
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 #, fuzzy
 msgid "MiB"
 msgstr "GiB"
 
-#. desklet.js:556
+#. desklet.js:567
 #, fuzzy
 msgid "KiB"
 msgstr "GiB"
@@ -149,11 +165,15 @@ msgid "Unit prefix for Filesystem size."
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->options
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->options
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr ""
+
+#. settings-schema.json->data-prefix-network->options
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/ru.po
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 msgid "CPU"
 msgstr "Процессор"
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr ""
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr ""
 
@@ -54,23 +54,39 @@ msgstr "Использовано Памяти"
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 msgid "B"
 msgstr ""
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 msgid "MiB"
 msgstr ""
 
-#. desklet.js:556
+#. desklet.js:567
 msgid "KiB"
 msgstr ""
 
@@ -142,12 +158,17 @@ msgstr "Система счисления для Файловых систем."
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr "Бинарная или IEC (1 GiB = 1024³ bytes)"
 
 #. settings-schema.json->data-prefix-network->options
 #, fuzzy
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr "Десятичная префикс (1 GB = 1000³ bytes)"
+
+#. settings-schema.json->data-prefix-network->options
+#, fuzzy
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr "Десятичная префикс (1 GB = 1000³ bytes)"
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/system-monitor-graph@rcassani.pot
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/po/system-monitor-graph@rcassani.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: system-monitor-graph@rcassani 2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-07-05 08:35-0400\n"
+"POT-Creation-Date: 2025-08-01 22:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid "CPU"
 msgstr ""
 
-#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:536
+#. desklet.js:194 desklet.js:212 desklet.js:232 desklet.js:273 desklet.js:547
 msgid "GB"
 msgstr ""
 
-#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:550
+#. desklet.js:197 desklet.js:215 desklet.js:235 desklet.js:276 desklet.js:561
 msgid "GiB"
 msgstr ""
 
@@ -57,23 +57,39 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#. desklet.js:525 desklet.js:544 desklet.js:558
+#. desklet.js:518 desklet.js:541
+msgid "b"
+msgstr ""
+
+#. desklet.js:520 desklet.js:555 desklet.js:569
 msgid "B"
 msgstr ""
 
+#. desklet.js:533
+msgid "Gb"
+msgstr ""
+
+#. desklet.js:536
+msgid "Mb"
+msgstr ""
+
 #. desklet.js:539
+msgid "Kb"
+msgstr ""
+
+#. desklet.js:550
 msgid "MB"
 msgstr ""
 
-#. desklet.js:542
+#. desklet.js:553
 msgid "KB"
 msgstr ""
 
-#. desklet.js:553
+#. desklet.js:564
 msgid "MiB"
 msgstr ""
 
-#. desklet.js:556
+#. desklet.js:567
 msgid "KiB"
 msgstr ""
 
@@ -144,11 +160,15 @@ msgid "Unit prefix for Filesystem size."
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->options
-msgid "Binary prefix or IEC (1 KiB = 1024 bytes)"
+msgid "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)"
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->options
-msgid "Decimal prefix (1 KB = 1000 bytes)"
+msgid "Bytes - Decimal prefix (1 KB = 1000 bytes)"
+msgstr ""
+
+#. settings-schema.json->data-prefix-network->options
+msgid "Bits - Decimal prefix (1 Kb = 1000 bits)"
 msgstr ""
 
 #. settings-schema.json->data-prefix-network->tooltip

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
@@ -61,7 +61,7 @@
         "options": {
             "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)" : 0,
             "Bytes - Decimal prefix (1 KB = 1000 bytes)" : 1,
-            "Bits (1 Kb = 1000 bit)" : 2
+            "Bits - Decimal prefix (1 Kb = 1000 bit)" : 2
         },
         "description": "Prefix for data units",
         "tooltip": "Unit prefix for network speed.",

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
@@ -61,7 +61,7 @@
         "options": {
             "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)" : 0,
             "Bytes - Decimal prefix (1 KB = 1000 bytes)" : 1,
-            "Bits - Decimal prefix (1 Kb = 1000 bit)" : 2
+            "Bits - Decimal prefix (1 Kb = 1000 bits)" : 2
         },
         "description": "Prefix for data units",
         "tooltip": "Unit prefix for network speed.",

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
@@ -59,8 +59,9 @@
         "type": "combobox",
         "default": 0,
         "options": {
-            "Binary prefix or IEC (1 KiB = 1024 bytes)" : 0,
-            "Decimal prefix (1 KB = 1000 bytes)" : 1
+            "Bits (1 Kb = 1000 bit)" : 2,
+            "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)" : 0,
+            "Bytes - Decimal prefix (1 KB = 1000 bytes)" : 1
         },
         "description": "Prefix for data units",
         "tooltip": "Unit prefix for network speed.",

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/settings-schema.json
@@ -59,9 +59,9 @@
         "type": "combobox",
         "default": 0,
         "options": {
-            "Bits (1 Kb = 1000 bit)" : 2,
             "Bytes - Binary prefix or IEC (1 KiB = 1024 bytes)" : 0,
-            "Bytes - Decimal prefix (1 KB = 1000 bytes)" : 1
+            "Bytes - Decimal prefix (1 KB = 1000 bytes)" : 1,
+            "Bits (1 Kb = 1000 bit)" : 2
         },
         "description": "Prefix for data units",
         "tooltip": "Unit prefix for network speed.",


### PR DESCRIPTION
- I think it makes more sense to display network speed as bits/sec rather than bytes/sec, so I added an option for that and made it the default.
- The up/download speed sometimes overlaps, depending on the amount of chars of the current network speed. That's why, I moved this info into the smaller, right-aligned `text3` label.
- Furthermore, I fixed some German translations.

What do you think @rcassani ?