### PR TITLE
quicklinks@NotSirius-A: Version 1.2

### DIFF
--- a/quicklinks@NotSirius-A/README.md
+++ b/quicklinks@NotSirius-A/README.md
@@ -18,16 +18,18 @@ This desklet was designed to help clean up desktops with lots of icons and impro
 
 You can customize this desklet to your taste. Choose from two layouts a list or tiles; change fonts, and icons or remove them entirely. You can use transparency or have solid colors, perhaps make the buttons large or compact. Check out the different options.
 
-### What can be improved?
+### Tips
 
-* This desklet could use more translations. I might add a Polish translation myself in the future.
+- You can add multiple desklets by clicking the "+" icons in your desklet manager.
+- You can backup your desklets by going to the settings. There you should find an icon in the top right corner. Select the `Export to a file` option or import to load your backup.
+- You can add a transparent border to your link to make them look bigger.
+- When you disable desklet decorations you can still grab the desklet by the invisible border around it.
+
+### What can be improved?
 
 * Improve font parsing.
 
-* More visual customizations could be added.
-
 * Unfortunately, the xlet settings API at this moment doesn't support `iconfilechooser` within `list` setting, so icons have to be typed in by name, which is somewhat annoying.
-
 
 
 ### Remarks

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/CHANGELOG.md
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+
+## [1.2] - 14.10.2025
+
+### Added
+
+- Added new border styling + settings
+- Added new spacing styling + settings
+- Option to disable tooltips
+- Invisible padding without desklet decorations to make it easier to grab
+
+### Changed
+
+- Some default settings
+- Some setting names/positions
+- Decreased link padding slightly in `stylesheet.css`
+
+### Fixed
+
+- Incorrect width scaling width different display scales
+
+
 ## [1.1] - 16.06.2025
 
 ### Added

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/metadata.json
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/metadata.json
@@ -2,7 +2,7 @@
     "max-instances": "10",
     "description": "Customizable quick links panel. Allows you to create beautiful themed desktop shortcuts for your most used folders/commands.",
     "name": "Quick Links",
-    "version": "1.1",
+    "version": "1.2",
     "uuid": "quicklinks@NotSirius-A",
     "author": "NotSirius-A"
 }

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/po/quicklinks@NotSirius-A.pot
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/po/quicklinks@NotSirius-A.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: quicklinks@NotSirius-A 1.1\n"
+"Project-Id-Version: quicklinks@NotSirius-A 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-06-16 14:10+0200\n"
+"POT-Creation-Date: 2025-10-14 20:05+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. desklet.js:130
+#. desklet.js:135
 msgid ""
 "No visible\n"
 "links found.\n"
@@ -28,7 +28,7 @@ msgid ""
 "then configure."
 msgstr ""
 
-#. desklet.js:344
+#. desklet.js:355
 msgid "Quick Links: Command parse error: "
 msgstr ""
 
@@ -46,8 +46,8 @@ msgstr ""
 msgid "Links"
 msgstr ""
 
-#. settings-schema.json->actions-page->title
-msgid "Actions"
+#. settings-schema.json->preferences-page->title
+msgid "Preferences"
 msgstr ""
 
 #. settings-schema.json->theme-page->title
@@ -62,8 +62,8 @@ msgstr ""
 msgid "Find icon names here"
 msgstr ""
 
-#. settings-schema.json->click-section->title
-msgid "Change how links are activated"
+#. settings-schema.json->general-section->title
+msgid "General"
 msgstr ""
 
 #. settings-schema.json->layout-section->title
@@ -207,6 +207,22 @@ msgstr ""
 msgid "Increase or decrease the number of columns on the layout."
 msgstr ""
 
+#. settings-schema.json->row-spacing->description
+msgid "Row spacing"
+msgstr ""
+
+#. settings-schema.json->row-spacing->tooltip
+msgid "Change how far apart are link rows."
+msgstr ""
+
+#. settings-schema.json->column-spacing->description
+msgid "Column spacing"
+msgstr ""
+
+#. settings-schema.json->column-spacing->tooltip
+msgid "Change how far apart are link columns."
+msgstr ""
+
 #. settings-schema.json->text-shadow->description
 msgid "Text shadow"
 msgstr ""
@@ -275,6 +291,24 @@ msgstr ""
 msgid "Set the text color of this desklet."
 msgstr ""
 
+#. settings-schema.json->link-border-width->description
+msgid "Border width (set to 0 to disable border)"
+msgstr ""
+
+#. settings-schema.json->link-border-width->tooltip
+msgid "Increase or decrease the link border width."
+msgstr ""
+
+#. settings-schema.json->link-border-color->description
+msgid "Border color"
+msgstr ""
+
+#. settings-schema.json->link-border-color->tooltip
+msgid ""
+"Set the link border color (Transparent border will add more padding to "
+"links)."
+msgstr ""
+
 #. settings-schema.json->scale-size->units
 msgid "scale factor"
 msgstr ""
@@ -303,4 +337,12 @@ msgstr ""
 msgid ""
 "Set your desklet header. Make sure desklet headers are enabled in system "
 "settings."
+msgstr ""
+
+#. settings-schema.json->are-tooltips-enabled->description
+msgid "Enable link tooltips"
+msgstr ""
+
+#. settings-schema.json->are-tooltips-enabled->tooltip
+msgid "Select if you want tooltips to show up when hovering over links."
 msgstr ""

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/settings-schema.json
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/settings-schema.json
@@ -3,7 +3,7 @@
         "type": "layout",
         "pages": [
             "links-page",
-            "actions-page",
+            "preferences-page",
             "theme-page"
         ],
         "links-page": {
@@ -14,11 +14,12 @@
                 "iconselect-section"
             ]
         },
-        "actions-page": {
+        "preferences-page": {
             "type": "page",
-            "title": "Actions",
+            "title": "Preferences",
             "sections": [
-                "click-section"
+                "general-section",
+                "desklet-decorations-section"
             ]
         },
         "theme-page": {
@@ -26,8 +27,7 @@
             "title": "Theme",
             "sections": [
                 "layout-section",
-                "font-section",
-                "desklet-decorations-section"
+                "font-section"
             ]
         },
         "links-section": {
@@ -48,12 +48,13 @@
                 "icon-picker"
             ]
         },
-        "click-section": {
+        "general-section": {
             "type": "section",
-            "title": "Change how links are activated",
+            "title": "General",
             "keys": [
                 "click-type",
-                "click-timeout"
+                "click-timeout",
+                "are-tooltips-enabled"
             ]
         },
         "layout-section": {
@@ -63,9 +64,13 @@
                 "scale-size",
                 "desklet-layout",
                 "column-number",
+                "row-spacing",
+                "column-spacing",
                 "text-align",
-                "transparent-bg",
                 "bg-color",
+                "transparent-bg",
+                "link-border-width",
+                "link-border-color",
                 "icon-size"
             ]
         },
@@ -98,7 +103,7 @@
     },
     "links-bottom-label": {
         "type": "label",
-        "description": "Some tips:\nYou can open folders using ex. `nemo <path>` command.\nIf you need to see the output of a command, set the last attribute to true.\nYou can break your links' names into multiple lines by typing \\n where you want a break.\nSet `Shell` to enabled if your command only outputs to the console ex. `ls` or `htop`.\nIf you want multiple link categories/panels just create new instances of this desklet\n (click the `+` sign in system desklet manager)."
+        "description": "Some tips:\nYou can open folders using ex. `nemo <path>` command.\nYou can break your links' names into multiple lines by typing \\n where you want a break.\nSet `Shell` to enabled if your command only outputs to the console ex. `ls` or `htop`.\nIf you want multiple link categories/panels just create new instances of this desklet\n (click the `+` sign in system desklet manager)."
     },
     "links-list" : {
         "type" : "list",
@@ -109,7 +114,7 @@
             {"id": "command", "title": "Command", "type": "string", "default": "nemo /"},
             {"id": "shell", "title": "Shell", "type": "boolean", "default": false, "align": 0}
         ],
-		"height": 275,
+		"height": 250,
         "default" : [
             {
                 "is-visible": true,
@@ -248,6 +253,25 @@
         "description": "Number of columns",
         "tooltip": "Increase or decrease the number of columns on the layout."
     },
+    "row-spacing": {
+        "type": "spinbutton",
+        "default": 5,
+        "min": 0,
+        "max": 25,
+        "step": 1,
+        "description": "Row spacing",
+        "tooltip": "Change how far apart are link rows."
+    },
+    "column-spacing": {
+        "type": "spinbutton",
+        "default": 5,
+        "min": 0,
+        "max": 25,
+        "step": 1,
+        "description": "Column spacing",
+        "tooltip": "Change how far apart are link columns.",
+        "dependency": "column-number>1"
+    },
     "text-shadow": {
         "type": "switch",
         "description": "Text shadow",
@@ -280,7 +304,7 @@
     },
     "icon-size": {
         "type": "spinbutton",
-        "default": 38,
+        "default": 35,
         "min": 0,
         "max": 200,
         "step": 1,
@@ -296,7 +320,7 @@
     "font": {
         "type": "fontchooser",
         "description": "Font name (choose regular versions)",
-        "default": "Noto Sans Regular 16",
+        "default": "Noto Sans Regular 13",
         "tooltip": "Change font family",
         "dependency": "font-enabled"
     },
@@ -319,6 +343,22 @@
         "dependency": "font-enabled",
         "tooltip": "Set the text color of this desklet."
     },
+    "link-border-width": {
+        "type": "spinbutton",
+        "default": 1,
+        "min": 0,
+        "max": 20,
+        "step": 1,
+        "description": "Border width (set to 0 to disable border)",
+        "tooltip": "Increase or decrease the link border width."
+    },
+    "link-border-color": {
+        "type": "colorchooser",
+        "default": "rgba(0,0,0,0.0)",
+        "description": "Border color",
+        "tooltip": "Set the link border color (Transparent border will add more padding to links).",
+        "dependency": "link-border-width>0"
+    },
     "scale-size": {
         "type": "spinbutton",
         "default": 2,
@@ -338,5 +378,11 @@
         "default": "Quick Links",
         "description": "Desklet header",
         "tooltip": "Set your desklet header. Make sure desklet headers are enabled in system settings."
+    },
+    "are-tooltips-enabled": {
+        "type": "switch",
+        "default": true,
+        "description": "Enable link tooltips",
+        "tooltip": "Select if you want tooltips to show up when hovering over links."
     }
 }

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/stylesheet.css
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/stylesheet.css
@@ -2,7 +2,7 @@
 	color: black;
 	font-weight: 500; /* normal */
 	border-radius: 0.32em;
-	padding: 0.25em 0.05em;
+	padding: 0.2em 0.05em;
 }
 
 .link:hover {
@@ -24,8 +24,8 @@
 }
 
 .list .link-icon {
-	padding-left: 0.35em;
-	padding-right: 0.55em;
+	padding-left: 0.08em;
+	padding-right: 0.5em;
 }
 
 .tile .link-icon {


### PR DESCRIPTION
Hello, I'm updating my desklet.

## [1.2] - 14.10.2025

### Added

- Added new border styling + settings
- Added new spacing styling + settings
- Option to disable tooltips
- Invisible padding without desklet decorations to make it easier to grab

### Changed

- Some default settings
- Some setting names/positions
- Decreased link padding slightly in `stylesheet.css`

### Fixed

- Incorrect width scaling width different display scales