### PR TITLE
calendar@deeppradhan: Add primary display setting

### DIFF
--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/ca.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/ca.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Daniel <d3vf4n (at) tutanota (dot) com>, 2023.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-14 23:55+0200\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2024-05-14 23:59+0200\n"
 "Last-Translator: Daniel <d3vf4n (at) tutanota (dot) com>\n"
 "Language-Team: \n"
@@ -19,93 +19,93 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Gener"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Febrer"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Març"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Abril"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Maig"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Juny"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Juliol"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Agost"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Setembre"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Octubre"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "Novembre"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Desembre"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Diumenge"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Dilluns"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Dimarts"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Dimecres"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Dijous"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Divendres"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Dissabte"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Mes anterior"
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Mes següent"
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Calendari"
 
@@ -153,6 +153,32 @@ msgstr "Mes"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Trieu els plafons que seran visibles en la miniaplicació"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Maig"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Mes"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/calendar@deeppradhan.pot
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/calendar@deeppradhan.pot
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# kanchudeep, 2018
 #
 #, fuzzy
 msgid ""
@@ -8,102 +8,102 @@ msgstr ""
 "Project-Id-Version: calendar@deeppradhan 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-14 23:55+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr ""
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr ""
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr ""
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr ""
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr ""
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr ""
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr ""
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr ""
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr ""
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr ""
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr ""
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr ""
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr ""
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr ""
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr ""
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr ""
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr ""
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr ""
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr ""
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr ""
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr ""
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr ""
 
@@ -147,6 +147,30 @@ msgstr ""
 
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
+msgstr ""
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Day"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Month"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
 msgstr ""
 
 #. settings-schema.json->show-weekday->description

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/da.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/da.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# kanchudeep, 2018
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2022-10-20 19:33+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -19,93 +19,93 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Januar"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Februar"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Marts"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "April"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Maj"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Juni"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Juli"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "August"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "September"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Oktober"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "November"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "December"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Søndag"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Mandag"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Tirsdag"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Onsdag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Torsdag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Fredag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Lørdag"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Forrige måned ..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Næste måned ..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Kalender"
 
@@ -153,6 +153,32 @@ msgstr "Kun måned"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Vælg de paneler, som skal vises i skrivebordsprogrammet"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Maj"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Kun måned"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/de.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/de.po
@@ -1,111 +1,111 @@
 # CINNAMON CALENDAR DESKLET TRANSLATIONS.
 # Copyright (c) 2018 Deep Pradhan
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# kanchudeep, 2018
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Calendar Desklet - 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
-"PO-Revision-Date: 2021-03-18 19:54+0100\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
+"PO-Revision-Date: 2025-10-17 20:30+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Januar"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Februar"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "März"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "April"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Mai"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Juni"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Juli"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "August"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "September"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Oktober"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "November"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Dezember"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Sonntag"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Montag"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Dienstag"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Mittwoch"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Donnerstag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Freitag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Samstag"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Voriger Monat…"
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Nächster Monat…"
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Kalender"
 
@@ -153,6 +153,30 @@ msgstr "Nur Monat"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Leisten auswählen, die im Desklet angezeigt werden sollen"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr "Primäranzeige"
+
+#. settings-schema.json->primary-display->options
+msgid "Day"
+msgstr "Tag"
+
+#. settings-schema.json->primary-display->options
+msgid "Month"
+msgstr "Monat"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr "Datum"
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr "Zeit"
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr "Der größte Text"
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/es.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/es.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# kanchudeep, 2018
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2024-03-15 15:10-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,93 +19,93 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Enero"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Febrero"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Marzo"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Abril"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Mayo"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Junio"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Julio"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Agosto"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Septiembre"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Octubre"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "Noviembre"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Diciembre"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Domingo"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Lunes"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Martes"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Jueves"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Viernes"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Sábado"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Mes anterior..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Próximo mes..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Calendario"
 
@@ -153,6 +153,32 @@ msgstr "Solo Mes"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Seleccione los paneles que se mostrarán en el desklet"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Mayo"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Solo Mes"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/fi.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/fi.po
@@ -1,110 +1,110 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# kanchudeep, 2018
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@deeppradhan 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-14 23:55+0200\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2024-11-07 11:14+0200\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Tammikuu"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Helmikuu"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Maaliskuu"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Huhtikuu"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Toukokuu"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Kesäkuu"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Heinäkuu"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Elokuu"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Syyskuu"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Lokakuu"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "Marraskuu"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Joulukuu"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Sunnuntai"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Maanantai"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Tiistai"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Keskiviikko"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Torstai"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Perjantai"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Launtai"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Edellinen kuukausi..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Seuraava kuukausi..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Kalenteri"
 
@@ -151,6 +151,32 @@ msgstr "Vain kuukausi"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Valitse työpöydällä näytettävät asiat"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Toukokuu"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Vain kuukausi"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/fr.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/fr.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# kanchudeep, 2018
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@deeppradhan 1.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2024-03-16 10:31+0100\n"
 "Last-Translator: \n"
 "Language-Team: Patrick Renaud\n"
@@ -18,93 +18,93 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Janvier"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Février"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Mars"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Avril"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Mai"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Juin"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Juillet"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Août"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Septembre"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Octobre"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "Novembre"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Décembre"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Dimanche"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Lundi"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Mardi"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Vendredi"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Samedi"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Mois précédent ..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Mois suivant ..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Desklet de calendrier configurable"
 
@@ -152,6 +152,32 @@ msgstr "Mois seulement"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Sélectionnez les panneaux à afficher dans le desklet"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Mai"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Mois seulement"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/hu.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/hu.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# kanchudeep, 2018
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@deeppradhan 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-06-29 04:26-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2024-06-29 04:34-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,93 +18,93 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Január"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Február"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Március"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Április"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Május"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Június"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Július"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Augusztus"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Szeptember"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Október"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "November"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "December"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Vasárnap"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Hétfő"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Kedd"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Szerda"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Csütörtök"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Péntek"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Szombat"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Előző hónap..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Következő hónap..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Naptár"
 
@@ -152,6 +152,32 @@ msgstr "Csak a hónap"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Válassza ki az asztalkalmazáson megjelenítendő paneleket"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Május"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Csak a hónap"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/it.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/it.po
@@ -1,14 +1,14 @@
 # CINNAMON CALENDAR DESKLET TRANSLATIONS.
 # Copyright (c) 2018 Deep Pradhan
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# kanchudeep, 2018
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Calendar Desklet - 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2025-08-26 19:23+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,93 +19,93 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Gennaio"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Febbraio"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Marzo"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Aprile"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Maggio"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Giugno"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Luglio"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Agosto"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Settembre"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Ottobre"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "Novembre"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Dicembre"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Domenica"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Lunedì"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Martedì"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Mercoledì"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Giovedì"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Venerdì"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Sabato"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Mese precedente..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Mese successivo..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Calendario"
 
@@ -153,6 +153,32 @@ msgstr "Solo il mese"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Seleziona i pannelli da mostrare nel desklet"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Maggio"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Solo il mese"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/nl.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/nl.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# kanchudeep, 2018
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: calendar@deeppradhan 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2024-04-18 14:06+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,93 +16,93 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Januari"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Februari"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Maart"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "April"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Mei"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Juni"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Juli"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Augustus"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "September"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Oktober"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "November"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "December"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Zondag"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Maandag"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Dinsdag"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Woensdag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Donderdag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Vrijdag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Zaterdag"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Vorige maand..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Volgende maand..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Kalender"
 
@@ -150,6 +150,32 @@ msgstr "Alleen Maand"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Selecteer de panelen die in de desklet worden weergegeven"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Mei"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Alleen Maand"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/pt_BR.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/pt_BR.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# CALENDAR DESKLET
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Marcelo Aof, 2021.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2021-09-28 11:32-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -19,93 +19,93 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Janeiro"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Fevereiro"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Março"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Abril"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Maio"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Junho"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Julho"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Agosto"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Setembro"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Outubro"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "Novembro"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Dezembro"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Domingo"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Segunda-feira"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Terça-feira"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Quarta-feira"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Quinta-feira"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Sexta-feira"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Sábado"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Mês anterior..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Próximo mês..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Calendário"
 
@@ -152,6 +152,32 @@ msgstr "Mês"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Selecione as colunas para mostrar no desklet"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Maio"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Mês"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/ro.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/ro.po
@@ -2,13 +2,13 @@
 # Copyright (C) 2023 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Automatically generated, 2023.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2021-03-18 19:52+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -19,93 +19,93 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
 "20)) ? 1 : 2;\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Ianuarie"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Februarie"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Martie"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Aprilie"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Mai"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Iunie"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Iulie"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "August"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Septembrie"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Octombrie"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "Noiembrie"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Decembrie"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Duminică"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Luni"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Marți"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Miercuri"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Joi"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Vineri"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Sâmbătă"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Luna precedentă..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Luna viitoare..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -153,6 +153,32 @@ msgstr "Numai luna"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Selectează panourile care urmează să fie afișate în desklet"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Mai"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Numai luna"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/ru.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/ru.po
@@ -1,10 +1,10 @@
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -14,93 +14,93 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.1\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Январь"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Февраль"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Март"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Апрель"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Май"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Июнь"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Июль"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Август"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "Сентябрь"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Октябрь"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "Ноябрь"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "Декабрь"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Воскресенье"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Понедельник"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Вторник"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Среда"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Четверг"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Пятница"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Суббота"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Предыдущий месяц..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Следующий месяц..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Календарь (Calendar)"
 
@@ -148,6 +148,32 @@ msgstr "Только месяц"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Выберите что отображать в календаре"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Май"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Только месяц"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/sk.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/sk.po
@@ -2,13 +2,13 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Dušan Kazik <prescott66@gmail.com>, 2021.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2021-02-09 16:50+0100\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: \n"
@@ -19,93 +19,93 @@ msgstr ""
 "X-Generator: Poedit 2.4.1\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Január"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Február"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Marec"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "Apríl"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Máj"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Jún"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Júl"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "August"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "September"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Október"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "November"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "December"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Nedeľa"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Pondelok"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Utorok"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Streda"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Štvrtok"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Piatok"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Sobota"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Predchádzajúci mesiac..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Nasledujúci mesiac..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Kalendár"
 
@@ -153,6 +153,32 @@ msgstr "Iba mesiac"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Vyberie panely, ktoré sa zobrazia v desklete"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Máj"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Iba mesiac"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/po/sv.po
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/po/sv.po
@@ -2,13 +2,13 @@
 # Copyright (c) 2018 Deep Pradhan
 # This file is distributed under the same license as the PACKAGE package.
 # Åke Engelbrektson <eson@svenskasprakfiler.se>, 2020.
-#
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: Calendar Desklet - 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2024-03-18 11:02-0400\n"
+"POT-Creation-Date: 2025-10-17 20:29+0200\n"
 "PO-Revision-Date: 2020-01-02 10:43+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -19,93 +19,93 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "January"
 msgstr "Januari"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "February"
 msgstr "Februari"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "March"
 msgstr "Mars"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "April"
 msgstr "April"
 
-#: desklet.js:29
+#. desklet.js:29
 msgid "May"
 msgstr "Maj"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "June"
 msgstr "Juni"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "July"
 msgstr "Juli"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "August"
 msgstr "Augusti"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "September"
 msgstr "September"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "October"
 msgstr "Oktober"
 
-#: desklet.js:30
+#. desklet.js:30
 msgid "November"
 msgstr "November"
 
-#: desklet.js:31
+#. desklet.js:31
 msgid "December"
 msgstr "December"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Sunday"
 msgstr "Söndag"
 
 #. settings-schema.json->first-day->options
-#: desklet.js:34
+#. desklet.js:34
 msgid "Monday"
 msgstr "Måndag"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Tuesday"
 msgstr "Tisdag"
 
-#: desklet.js:34
+#. desklet.js:34
 msgid "Wednesday"
 msgstr "Onsdag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Thursday"
 msgstr "Torsdag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Friday"
 msgstr "Fredag"
 
-#: desklet.js:35
+#. desklet.js:35
 msgid "Saturday"
 msgstr "Lördag"
 
-#: desklet.js:135
+#. desklet.js:136
 msgid "Previous month..."
 msgstr "Föregående månad..."
 
-#: desklet.js:137
+#. desklet.js:138
 msgid "Next month..."
 msgstr "Nästa månad..."
 
-#: desklet.js:152
+#. desklet.js:153
 msgid "Calendar"
 msgstr "Kalender"
 
@@ -153,6 +153,32 @@ msgstr "Endast månad"
 #. settings-schema.json->panels->tooltip
 msgid "Select the panels to display in desklet"
 msgstr "Välj vilka paneler som visas i programmet"
+
+#. settings-schema.json->primary-display->description
+msgid "Primary display"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Day"
+msgstr "Maj"
+
+#. settings-schema.json->primary-display->options
+#, fuzzy
+msgid "Month"
+msgstr "Endast månad"
+
+#. settings-schema.json->primary-display->options
+msgid "Date"
+msgstr ""
+
+#. settings-schema.json->primary-display->options
+msgid "Time"
+msgstr ""
+
+#. settings-schema.json->primary-display->tooltip
+msgid "The biggest text"
+msgstr ""
 
 #. settings-schema.json->show-weekday->description
 msgid "Show day of week"

--- a/calendar@deeppradhan/files/calendar@deeppradhan/settings-schema.json
+++ b/calendar@deeppradhan/files/calendar@deeppradhan/settings-schema.json
@@ -14,6 +14,19 @@
         },
         "tooltip": "Select the panels to display in desklet"
     },
+    "primary-display": {
+        "type": "combobox",
+        "default": "date",
+        "description": "Primary display",
+        "options": {
+            "Day": "day",
+            "Month": "month",
+            "Date": "date",
+            "Time": "time"
+        },
+        "tooltip": "The biggest text",
+        "dependency": "panels!=month"
+    },
     "show-weekday": {
         "type": "combobox",
         "default": "full",


### PR DESCRIPTION
This closes a feature request. I've added a setting to adjust the primary display. The primary display will be displayed with larger font and will always be in second position.

closes #1447