### PR TITLE
[moonlight-clock@torchipeppo] v1.1.1: Add selectable moon countdown

### DIFF
--- a/moonlight-clock@torchipeppo/TRANSLATORS.md
+++ b/moonlight-clock@torchipeppo/TRANSLATORS.md
@@ -92,6 +92,10 @@ this read "Shadow" or "Text shadow".
 These refer to the target dates you count down to, in case this
 guides the choice of grammatical gender for languages where it matters.
 
+### Emoji
+One list-type setting has emoji headings to keep it compact.
+Please leave the emoji.
+
 
 ## Coherence with Cinnamon
 

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/constants.js
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/constants.js
@@ -1,6 +1,8 @@
 const Translation = require("./translation");
 const _ = Translation._;
 
+const ONE_DAY_MSEC = 1000 * 60 * 60 * 24;
+
 const CAPTION_TYPE_SPECS = {
     "" : {
         caption_label: "",
@@ -73,38 +75,26 @@ const FONT_WEIGHTS_TO_NUMERIC = {
 const FONT_WEIGHTS = Object.keys(FONT_WEIGHTS_TO_NUMERIC);
 const FONT_STYLES = ["italic", "oblique"]
 
-const MOON_PHASES_BY_WEATHERAPI_NAME = {
-    "New Moon": "🌑",
-    "Waxing Crescent": "🌒",
-    "First Quarter": "🌓",
-    "Waxing Gibbous": "🌔",
-    "Full Moon": "🌕",
-    "Waning Gibbous": "🌖",
-    "Last Quarter": "🌗",
-    "Waning Crescent": "🌘",
+const MOON_PHASE_EMOJIS = {
+    "new": "🌑",
+    "new-fq": "🌒",
+    "fq": "🌓",
+    "fq-full": "🌔",
+    "full": "🌕",
+    "full-lq": "🌖",
+    "lq": "🌗",
+    "lq-new": "🌘",
 }
 
-const MOON_PHASE_NAMES_BY_LUNCAL_RESULT = {
-    "new": "New Moon",
-    "new-fq": "Waxing Crescent",
-    "fq": "First Quarter",
-    "fq-full": "Waxing Gibbous",
-    "full": "Full Moon",
-    "full-lq": "Waning Gibbous",
-    "lq": "Last Quarter",
-    "lq-new": "Waning Crescent",
-}
-
-// to mark them with the _() function
-const TRANSLATED_MOON_PHASE_NAMES = {
-    "New Moon": _("New Moon"),
-    "Waxing Crescent": _("Waxing Crescent"),
-    "First Quarter": _("First Quarter"),
-    "Waxing Gibbous": _("Waxing Gibbous"),
-    "Full Moon": _("Full Moon"),
-    "Waning Gibbous": _("Waning Gibbous"),
-    "Last Quarter": _("Last Quarter"),
-    "Waning Crescent": _("Waning Crescent"),
+const MOON_PHASE_NAMES = {
+    "new": _("New Moon"),
+    "new-fq": _("Waxing Crescent"),
+    "fq": _("First Quarter"),
+    "fq-full": _("Waxing Gibbous"),
+    "full": _("Full Moon"),
+    "full-lq": _("Waning Gibbous"),
+    "lq": _("Last Quarter"),
+    "lq-new": _("Waning Crescent"),
 }
 
 const MOON_PHASE_SHORTNAMES = {

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/desklet.js
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/desklet.js
@@ -53,6 +53,7 @@ const text_content_keys = [
     "date_weekday_enabled",
     "emoji_type",
     "caption_type",
+    "moon_countdown_selection",
     "show_secondary_countdowns",
 ];
 const countdown_keys = [
@@ -128,6 +129,7 @@ class P3Desklet extends Desklet.Desklet {
         this.settings.bind("bottom-caption-shadow", "caption_shadow_enabled", this._onUISettingsChanged);
         this.settings.bind("bottom-caption-shadow-offset", "caption_shadow_offset", this._onUISettingsChanged);
         this.settings.bind("bottom-show-secondary-countdowns", "show_secondary_countdowns", this._onUISettingsChanged);
+        this.settings.bind("bottom-moon-countdown-selection", "moon_countdown_selection", this._onSettingsChanged);
 
         this.settings.bind("custom-countdown-list", "countdown_list", this._onSettingsChanged);
 
@@ -312,8 +314,6 @@ class P3Desklet extends Desklet.Desklet {
     }
 
     _updateClock() {
-        // global.log("BABYBABYBABYBABYBABY");
-
         let formatted_time = this.clock_source.get_time_text();
         this._time_label.set_text(formatted_time);
         this._time_shadow_label.set_text(this.time_shadow_enabled ? formatted_time : "");

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/settings-schema.json
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/settings-schema.json
@@ -113,6 +113,7 @@
             "title": "Caption settings",
             "keys": [
                 "bottom-caption-type",
+                "bottom-moon-countdown-selection",
                 "bottom-caption-font",
                 "bottom-caption-v-offset",
                 "bottom-caption-shadow",
@@ -407,7 +408,7 @@
             "Temperature °C (W)": "temp-c",
             "Temperature °F (W)": "temp-f",
             "Moon phase (C?)": "moon",
-            "Full moon countdown (C?)": "cntdn-full",
+            "Moon countdown (C?)": "cntdn-full",
             "Custom countdown (D)": "cntdn-cstm"
         },
         "description": "Caption display"
@@ -447,6 +448,28 @@
         "default": true,
         "description": "Show more countdowns in secondary text (D)",
         "dependency": "bottom-caption-type!="
+    },
+    "bottom-moon-countdown-selection": {
+        "type": "list",
+        "columns": [
+            {"id": "prompt", "title": "Select moon phases", "type": "string", "default": "-->"},
+            {"id": "new",  "title": "🌑", "type": "boolean", "default": false},
+            {"id": "fq",   "title": "🌓", "type": "boolean", "default": false},
+            {"id": "full", "title": "🌕", "type": "boolean", "default": true},
+            {"id": "lq",   "title": "🌗", "type": "boolean", "default": false},
+            {"id": "filler", "title": "", "type": "string", "default": "<--"}
+        ],
+        "default": [{
+            "prompt": "-->",
+            "new": false,
+            "fq": false,
+            "full": true,
+            "lq": false,
+            "filler": "<--"
+        }],
+        "height": 20,
+        "show-buttons": false,
+        "dependency": "bottom-caption-type=cntdn-full"
     },
 
 

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/settingsWidgets.py
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/settingsWidgets.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python3
 
+# for SettingsWidget and the _() function
+# pyright: reportMissingImports=false
+# pyright: reportUndefinedVariable=false
+
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version("GLib", "2.0")
@@ -120,7 +124,6 @@ class ListOfDates(SettingsWidget):
     bind_dir = None
 
     def __init__(self, info, key, settings):
-        # log("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
         self.info = info
         self.key = key
         self.settings = settings

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/wallclock_source.js
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/3.4/wallclock_source.js
@@ -4,6 +4,7 @@
 
 const Settings = imports.ui.settings;
 
+const CONSTANTS = require("./constants");
 const ShellUtils = require("./shell_utils");
 const Translation = require("./translation");
 const _ = Translation._;
@@ -44,7 +45,7 @@ function _get_days_left(date_json_string) {
         countdown_target.d
     );
 
-    return Math.round((target - today) / (1000 * 60 * 60 * 24));
+    return Math.round((target - today) / (CONSTANTS.ONE_DAY_MSEC));
 }
 
 class WallclockSource {

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/metadata.json
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/metadata.json
@@ -4,7 +4,7 @@
     "description": "An aesthetic and customizable desklet that can function as clock, weather display, and/or tracker of important dates. Based on Persona 3.",
     "comments": "Best placed in the top right corner on the screen. Use the \"offset\" configuration for precise alignment.",
     "author": "torchipeppo",
-    "version": "1.0.1",
+    "version": "1.1.1",
     "prevent-decorations": true,
     "multiversion": true
 }

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/ca.po
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/ca.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: moonlight-clock@torchipeppo 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-08 19:15+0100\n"
+"POT-Creation-Date: 2025-10-22 18:32+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,78 +22,78 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 3.4/constants.js:43 5.4/constants.js:43
+#. 3.4/constants.js:45 5.4/constants.js:45
 msgid "Next"
 msgstr "Següent"
 
-#. 3.4/constants.js:100 5.4/constants.js:100
+#. 3.4/constants.js:90 5.4/constants.js:90
 msgid "New Moon"
 msgstr "Lluna nova"
 
-#. 3.4/constants.js:101 5.4/constants.js:101
+#. 3.4/constants.js:91 5.4/constants.js:91
 msgid "Waxing Crescent"
 msgstr "Quart creixent"
 
-#. 3.4/constants.js:102 5.4/constants.js:102
+#. 3.4/constants.js:92 5.4/constants.js:92
 msgid "First Quarter"
 msgstr "Primer quart"
 
-#. 3.4/constants.js:103 5.4/constants.js:103
+#. 3.4/constants.js:93 5.4/constants.js:93
 msgid "Waxing Gibbous"
 msgstr "Lluna gibosa creixent"
 
-#. 3.4/constants.js:104 5.4/constants.js:104
+#. 3.4/constants.js:94 5.4/constants.js:94
 msgid "Full Moon"
 msgstr "Lluna plena"
 
-#. 3.4/constants.js:105 5.4/constants.js:105
+#. 3.4/constants.js:95 5.4/constants.js:95
 msgid "Waning Gibbous"
 msgstr "Lluna gibosa minvant"
 
-#. 3.4/constants.js:106 5.4/constants.js:106
+#. 3.4/constants.js:96 5.4/constants.js:96
 msgid "Last Quarter"
 msgstr "Últim quart"
 
-#. 3.4/constants.js:107 5.4/constants.js:107
+#. 3.4/constants.js:97 5.4/constants.js:97
 msgid "Waning Crescent"
 msgstr "Quart minvant"
 
-#. 3.4/constants.js:111 5.4/constants.js:111
+#. 3.4/constants.js:101 5.4/constants.js:101
 msgid "New"
 msgstr "Nova"
 
-#. 3.4/constants.js:112 3.4/constants.js:114 5.4/constants.js:112
-#. 5.4/constants.js:114
+#. 3.4/constants.js:102 3.4/constants.js:104 5.4/constants.js:102
+#. 5.4/constants.js:104
 msgid "Half"
 msgstr "Mitja"
 
-#. 3.4/constants.js:113 5.4/constants.js:113
+#. 3.4/constants.js:103 5.4/constants.js:103
 msgid "Full"
 msgstr "Plena"
 
-#. 3.4/constants.js:170 5.4/constants.js:170
+#. 3.4/constants.js:160 5.4/constants.js:160
 msgid "Clear"
 msgstr "Clar"
 
-#. 3.4/constants.js:171 3.4/constants.js:172 5.4/constants.js:171
-#. 5.4/constants.js:172
+#. 3.4/constants.js:161 3.4/constants.js:162 5.4/constants.js:161
+#. 5.4/constants.js:162
 msgid "Cloudy"
 msgstr "Ennuvolat"
 
-#. 3.4/constants.js:173 5.4/constants.js:173
+#. 3.4/constants.js:163 5.4/constants.js:163
 msgid "Fog"
 msgstr "Boira"
 
-#. 3.4/constants.js:174 3.4/constants.js:175 3.4/weatherapi_source.js:154
-#. 5.4/constants.js:174 5.4/constants.js:175 5.4/weatherapi_source.js:154
+#. 3.4/constants.js:164 3.4/constants.js:165 3.4/weatherapi_source.js:154
+#. 5.4/constants.js:164 5.4/constants.js:165 5.4/weatherapi_source.js:154
 msgid "Rain"
 msgstr "Pluja"
 
-#. 3.4/constants.js:176 5.4/constants.js:176
+#. 3.4/constants.js:166 5.4/constants.js:166
 msgid "Storm"
 msgstr "Tempesta"
 
-#. 3.4/constants.js:177 5.4/constants.js:177
+#. 3.4/constants.js:167 5.4/constants.js:167
 msgid ""
 "Cold\n"
 "precip."
@@ -101,11 +101,11 @@ msgstr ""
 "Precip.\n"
 "Freda"
 
-#. 3.4/desklet.js:149 5.4/desklet.js:149
+#. 3.4/desklet.js:143 5.4/desklet.js:143
 msgid "Date and Time Settings"
 msgstr "Opcions de data i hora"
 
-#. 3.4/desklet.js:408 3.4/desklet.js:439 5.4/desklet.js:408 5.4/desklet.js:439
+#. 3.4/desklet.js:400 3.4/desklet.js:431 5.4/desklet.js:400 5.4/desklet.js:431
 msgid "Limit"
 msgstr "Límit"
 
@@ -113,11 +113,11 @@ msgstr "Límit"
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-emoji-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-#. 3.4/desklet.js:412 5.4/desklet.js:412
+#. 3.4/desklet.js:404 5.4/desklet.js:404
 msgid "None"
 msgstr "Cap"
 
-#. 3.4/desklet.js:454 5.4/desklet.js:454
+#. 3.4/desklet.js:446 5.4/desklet.js:446
 msgid ""
 "Right-click\n"
 "to configure!"
@@ -126,35 +126,35 @@ msgstr ""
 "per configurar!"
 
 #. metadata.json->name
-#. 3.4/desklet.js:507 5.4/desklet.js:507
+#. 3.4/desklet.js:499 5.4/desklet.js:499
 msgid "Moonlight Clock"
 msgstr "Rellotge de fases lunars"
 
-#. 3.4/wallclock_source.js:13 5.4/wallclock_source.js:13
+#. 3.4/wallclock_source.js:14 5.4/wallclock_source.js:14
 msgid "Late Night"
 msgstr "Alta nit"
 
-#. 3.4/wallclock_source.js:16 5.4/wallclock_source.js:16
+#. 3.4/wallclock_source.js:17 5.4/wallclock_source.js:17
 msgid "Early Morning"
 msgstr "Matinada"
 
-#. 3.4/wallclock_source.js:19 5.4/wallclock_source.js:19
+#. 3.4/wallclock_source.js:20 5.4/wallclock_source.js:20
 msgid "Morning"
 msgstr "Matí"
 
-#. 3.4/wallclock_source.js:22 5.4/wallclock_source.js:22
+#. 3.4/wallclock_source.js:23 5.4/wallclock_source.js:23
 msgid "Daytime"
 msgstr "De dia"
 
-#. 3.4/wallclock_source.js:25 5.4/wallclock_source.js:25
+#. 3.4/wallclock_source.js:26 5.4/wallclock_source.js:26
 msgid "Afternoon"
 msgstr "Tarda"
 
-#. 3.4/wallclock_source.js:28 5.4/wallclock_source.js:28
+#. 3.4/wallclock_source.js:29 5.4/wallclock_source.js:29
 msgid "Evening"
 msgstr "Vespre"
 
-#. 3.4/wallclock_source.js:125 5.4/wallclock_source.js:125
+#. 3.4/wallclock_source.js:126 5.4/wallclock_source.js:126
 msgid "Today"
 msgstr "Avui"
 
@@ -191,44 +191,44 @@ msgstr "Carregar"
 msgid "Save"
 msgstr "Desar"
 
-#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
+#. 3.4/settingsWidgets.py:128 5.4/settingsWidgets.py:128
 msgid "Enabled"
 msgstr "Activat"
 
-#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
+#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
 msgid "Persistent"
 msgstr "Persistent"
 
-#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
+#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
 msgid "Date"
 msgstr "Data"
 
-#. 3.4/settingsWidgets.py:132 5.4/settingsWidgets.py:132
+#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
 msgid "Name"
 msgstr "Nom"
 
-#. 3.4/settingsWidgets.py:233 3.4/settingsWidgets.py:329
-#. 5.4/settingsWidgets.py:233 5.4/settingsWidgets.py:329
+#. 3.4/settingsWidgets.py:232 3.4/settingsWidgets.py:328
+#. 5.4/settingsWidgets.py:232 5.4/settingsWidgets.py:328
 msgid "Add new entry"
 msgstr "Afegir entrada nova"
 
-#. 3.4/settingsWidgets.py:237 5.4/settingsWidgets.py:237
+#. 3.4/settingsWidgets.py:236 5.4/settingsWidgets.py:236
 msgid "Remove selected entry"
 msgstr "Eliminar entrada seleccionada"
 
-#. 3.4/settingsWidgets.py:242 5.4/settingsWidgets.py:242
+#. 3.4/settingsWidgets.py:241 5.4/settingsWidgets.py:241
 msgid "Edit selected entry"
 msgstr "Editar entrada seleccionada"
 
-#. 3.4/settingsWidgets.py:247 5.4/settingsWidgets.py:247
+#. 3.4/settingsWidgets.py:246 5.4/settingsWidgets.py:246
 msgid "Move selected entry up"
 msgstr "Mou l'entrada seleccionada cap amunt"
 
-#. 3.4/settingsWidgets.py:252 5.4/settingsWidgets.py:252
+#. 3.4/settingsWidgets.py:251 5.4/settingsWidgets.py:251
 msgid "Move selected entry down"
 msgstr "Mou l'entrada seleccionada cap avall"
 
-#. 3.4/settingsWidgets.py:331 5.4/settingsWidgets.py:331
+#. 3.4/settingsWidgets.py:330 5.4/settingsWidgets.py:330
 msgid "Edit entry"
 msgstr "Editar entrada"
 
@@ -677,7 +677,8 @@ msgstr "Temperatura ºF (W)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-msgid "Full moon countdown (C?)"
+#, fuzzy
+msgid "Moon countdown (C?)"
 msgstr "Compte enrere per a la lluna plena (C?)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
@@ -695,12 +696,37 @@ msgstr "Mostrar textos"
 msgid "Show more countdowns in secondary text (D)"
 msgstr "Mostrar més comptes enrere al text secundari (D)"
 
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "Select moon phases"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌑"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌓"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌕"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌗"
+msgstr ""
+
 #. 3.4->settings-schema.json->custom-countdown-list-label->description
 #. 5.4->settings-schema.json->custom-countdown-list-label->description
 msgid ""
-"Enter one or more dates to count down to when selecting \"Custom countdown\" "
-"(1 date) and/or \"Show more countdowns in secondary text\" (up to 2 "
-"additional dates).\n"
+"Enter one or more dates to count down to when selecting \"Custom "
+"countdown\" (1 date) and/or \"Show more countdowns in secondary text\" (up "
+"to 2 additional dates).\n"
 "The order of the list represents the priority order for the dates.\n"
 "Disable dates to skip them.\n"
 "Dates set in the past are also skipped unless they are \"persistent\".\n"

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/es.po
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/es.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: moonlight-clock@torchipeppo 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-08 19:15+0100\n"
+"POT-Creation-Date: 2025-10-22 18:32+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,78 +21,78 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 3.4/constants.js:43 5.4/constants.js:43
+#. 3.4/constants.js:45 5.4/constants.js:45
 msgid "Next"
 msgstr "Siguiente"
 
-#. 3.4/constants.js:100 5.4/constants.js:100
+#. 3.4/constants.js:90 5.4/constants.js:90
 msgid "New Moon"
 msgstr "Luna nueva"
 
-#. 3.4/constants.js:101 5.4/constants.js:101
+#. 3.4/constants.js:91 5.4/constants.js:91
 msgid "Waxing Crescent"
 msgstr "Luna nueva visible"
 
-#. 3.4/constants.js:102 5.4/constants.js:102
+#. 3.4/constants.js:92 5.4/constants.js:92
 msgid "First Quarter"
 msgstr "Cuarto creciente"
 
-#. 3.4/constants.js:103 5.4/constants.js:103
+#. 3.4/constants.js:93 5.4/constants.js:93
 msgid "Waxing Gibbous"
 msgstr "Gibosa creciente"
 
-#. 3.4/constants.js:104 5.4/constants.js:104
+#. 3.4/constants.js:94 5.4/constants.js:94
 msgid "Full Moon"
 msgstr "Luna llena"
 
-#. 3.4/constants.js:105 5.4/constants.js:105
+#. 3.4/constants.js:95 5.4/constants.js:95
 msgid "Waning Gibbous"
 msgstr "Gibosa menguante"
 
-#. 3.4/constants.js:106 5.4/constants.js:106
+#. 3.4/constants.js:96 5.4/constants.js:96
 msgid "Last Quarter"
 msgstr "Cuarto menguante"
 
-#. 3.4/constants.js:107 5.4/constants.js:107
+#. 3.4/constants.js:97 5.4/constants.js:97
 msgid "Waning Crescent"
 msgstr "Luna menguante"
 
-#. 3.4/constants.js:111 5.4/constants.js:111
+#. 3.4/constants.js:101 5.4/constants.js:101
 msgid "New"
 msgstr "Nueva"
 
-#. 3.4/constants.js:112 3.4/constants.js:114 5.4/constants.js:112
-#. 5.4/constants.js:114
+#. 3.4/constants.js:102 3.4/constants.js:104 5.4/constants.js:102
+#. 5.4/constants.js:104
 msgid "Half"
 msgstr "Media"
 
-#. 3.4/constants.js:113 5.4/constants.js:113
+#. 3.4/constants.js:103 5.4/constants.js:103
 msgid "Full"
 msgstr "Llena"
 
-#. 3.4/constants.js:170 5.4/constants.js:170
+#. 3.4/constants.js:160 5.4/constants.js:160
 msgid "Clear"
 msgstr "Despejado"
 
-#. 3.4/constants.js:171 3.4/constants.js:172 5.4/constants.js:171
-#. 5.4/constants.js:172
+#. 3.4/constants.js:161 3.4/constants.js:162 5.4/constants.js:161
+#. 5.4/constants.js:162
 msgid "Cloudy"
 msgstr "Nuvoso"
 
-#. 3.4/constants.js:173 5.4/constants.js:173
+#. 3.4/constants.js:163 5.4/constants.js:163
 msgid "Fog"
 msgstr "Niebla"
 
-#. 3.4/constants.js:174 3.4/constants.js:175 3.4/weatherapi_source.js:154
-#. 5.4/constants.js:174 5.4/constants.js:175 5.4/weatherapi_source.js:154
+#. 3.4/constants.js:164 3.4/constants.js:165 3.4/weatherapi_source.js:154
+#. 5.4/constants.js:164 5.4/constants.js:165 5.4/weatherapi_source.js:154
 msgid "Rain"
 msgstr "Lluvia"
 
-#. 3.4/constants.js:176 5.4/constants.js:176
+#. 3.4/constants.js:166 5.4/constants.js:166
 msgid "Storm"
 msgstr "Tormenta"
 
-#. 3.4/constants.js:177 5.4/constants.js:177
+#. 3.4/constants.js:167 5.4/constants.js:167
 msgid ""
 "Cold\n"
 "precip."
@@ -100,11 +100,11 @@ msgstr ""
 "Precip.\n"
 "frío"
 
-#. 3.4/desklet.js:149 5.4/desklet.js:149
+#. 3.4/desklet.js:143 5.4/desklet.js:143
 msgid "Date and Time Settings"
 msgstr "Configuración de fecha y hora"
 
-#. 3.4/desklet.js:408 3.4/desklet.js:439 5.4/desklet.js:408 5.4/desklet.js:439
+#. 3.4/desklet.js:400 3.4/desklet.js:431 5.4/desklet.js:400 5.4/desklet.js:431
 msgid "Limit"
 msgstr "Límite"
 
@@ -112,11 +112,11 @@ msgstr "Límite"
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-emoji-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-#. 3.4/desklet.js:412 5.4/desklet.js:412
+#. 3.4/desklet.js:404 5.4/desklet.js:404
 msgid "None"
 msgstr "Ninguno"
 
-#. 3.4/desklet.js:454 5.4/desklet.js:454
+#. 3.4/desklet.js:446 5.4/desklet.js:446
 msgid ""
 "Right-click\n"
 "to configure!"
@@ -125,35 +125,35 @@ msgstr ""
 "para configurar!"
 
 #. metadata.json->name
-#. 3.4/desklet.js:507 5.4/desklet.js:507
+#. 3.4/desklet.js:499 5.4/desklet.js:499
 msgid "Moonlight Clock"
 msgstr "Reloj de luz de luna"
 
-#. 3.4/wallclock_source.js:13 5.4/wallclock_source.js:13
+#. 3.4/wallclock_source.js:14 5.4/wallclock_source.js:14
 msgid "Late Night"
 msgstr "Tarde noche"
 
-#. 3.4/wallclock_source.js:16 5.4/wallclock_source.js:16
+#. 3.4/wallclock_source.js:17 5.4/wallclock_source.js:17
 msgid "Early Morning"
 msgstr "Madrugada"
 
-#. 3.4/wallclock_source.js:19 5.4/wallclock_source.js:19
+#. 3.4/wallclock_source.js:20 5.4/wallclock_source.js:20
 msgid "Morning"
 msgstr "Por la mañana"
 
-#. 3.4/wallclock_source.js:22 5.4/wallclock_source.js:22
+#. 3.4/wallclock_source.js:23 5.4/wallclock_source.js:23
 msgid "Daytime"
 msgstr "De día"
 
-#. 3.4/wallclock_source.js:25 5.4/wallclock_source.js:25
+#. 3.4/wallclock_source.js:26 5.4/wallclock_source.js:26
 msgid "Afternoon"
 msgstr "Por la tarde"
 
-#. 3.4/wallclock_source.js:28 5.4/wallclock_source.js:28
+#. 3.4/wallclock_source.js:29 5.4/wallclock_source.js:29
 msgid "Evening"
 msgstr "Por la noche"
 
-#. 3.4/wallclock_source.js:125 5.4/wallclock_source.js:125
+#. 3.4/wallclock_source.js:126 5.4/wallclock_source.js:126
 msgid "Today"
 msgstr "Hoy"
 
@@ -190,44 +190,44 @@ msgstr "Cargar"
 msgid "Save"
 msgstr "Guardar"
 
-#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
+#. 3.4/settingsWidgets.py:128 5.4/settingsWidgets.py:128
 msgid "Enabled"
 msgstr "Habilitada"
 
-#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
+#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
 msgid "Persistent"
 msgstr "Persistente"
 
-#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
+#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
 msgid "Date"
 msgstr "Fecha"
 
-#. 3.4/settingsWidgets.py:132 5.4/settingsWidgets.py:132
+#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
 msgid "Name"
 msgstr "Nombre"
 
-#. 3.4/settingsWidgets.py:233 3.4/settingsWidgets.py:329
-#. 5.4/settingsWidgets.py:233 5.4/settingsWidgets.py:329
+#. 3.4/settingsWidgets.py:232 3.4/settingsWidgets.py:328
+#. 5.4/settingsWidgets.py:232 5.4/settingsWidgets.py:328
 msgid "Add new entry"
 msgstr "Añadir nueva entrada"
 
-#. 3.4/settingsWidgets.py:237 5.4/settingsWidgets.py:237
+#. 3.4/settingsWidgets.py:236 5.4/settingsWidgets.py:236
 msgid "Remove selected entry"
 msgstr "Eliminar la entrada seleccionada"
 
-#. 3.4/settingsWidgets.py:242 5.4/settingsWidgets.py:242
+#. 3.4/settingsWidgets.py:241 5.4/settingsWidgets.py:241
 msgid "Edit selected entry"
 msgstr "Editar la entrada seleccionada"
 
-#. 3.4/settingsWidgets.py:247 5.4/settingsWidgets.py:247
+#. 3.4/settingsWidgets.py:246 5.4/settingsWidgets.py:246
 msgid "Move selected entry up"
 msgstr "Mover la entrada seleccionada hacia arriba"
 
-#. 3.4/settingsWidgets.py:252 5.4/settingsWidgets.py:252
+#. 3.4/settingsWidgets.py:251 5.4/settingsWidgets.py:251
 msgid "Move selected entry down"
 msgstr "Mover la entrada seleccionada hacia abajo"
 
-#. 3.4/settingsWidgets.py:331 5.4/settingsWidgets.py:331
+#. 3.4/settingsWidgets.py:330 5.4/settingsWidgets.py:330
 msgid "Edit entry"
 msgstr "Editar entrada"
 
@@ -673,7 +673,8 @@ msgstr "Temperatura °F (O)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-msgid "Full moon countdown (C?)"
+#, fuzzy
+msgid "Moon countdown (C?)"
 msgstr "Cuenta regresiva de luna llena (C?)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
@@ -691,12 +692,37 @@ msgstr "Mostrar subtítulos"
 msgid "Show more countdowns in secondary text (D)"
 msgstr "Mostrar más cuentas regresivas en el texto secundario (D)"
 
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "Select moon phases"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌑"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌓"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌕"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌗"
+msgstr ""
+
 #. 3.4->settings-schema.json->custom-countdown-list-label->description
 #. 5.4->settings-schema.json->custom-countdown-list-label->description
 msgid ""
-"Enter one or more dates to count down to when selecting \"Custom countdown\" "
-"(1 date) and/or \"Show more countdowns in secondary text\" (up to 2 "
-"additional dates).\n"
+"Enter one or more dates to count down to when selecting \"Custom "
+"countdown\" (1 date) and/or \"Show more countdowns in secondary text\" (up "
+"to 2 additional dates).\n"
 "The order of the list represents the priority order for the dates.\n"
 "Disable dates to skip them.\n"
 "Dates set in the past are also skipped unless they are \"persistent\".\n"

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/hu.po
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/hu.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: moonlight-clock@torchipeppo 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-08 19:15+0100\n"
+"POT-Creation-Date: 2025-10-22 18:32+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,78 +22,78 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 3.4/constants.js:43 5.4/constants.js:43
+#. 3.4/constants.js:45 5.4/constants.js:45
 msgid "Next"
 msgstr "Következő"
 
-#. 3.4/constants.js:100 5.4/constants.js:100
+#. 3.4/constants.js:90 5.4/constants.js:90
 msgid "New Moon"
 msgstr "Újhold"
 
-#. 3.4/constants.js:101 5.4/constants.js:101
+#. 3.4/constants.js:91 5.4/constants.js:91
 msgid "Waxing Crescent"
 msgstr "Növekvő sarló"
 
-#. 3.4/constants.js:102 5.4/constants.js:102
+#. 3.4/constants.js:92 5.4/constants.js:92
 msgid "First Quarter"
 msgstr "Első negyed"
 
-#. 3.4/constants.js:103 5.4/constants.js:103
+#. 3.4/constants.js:93 5.4/constants.js:93
 msgid "Waxing Gibbous"
 msgstr "Növekvő domború"
 
-#. 3.4/constants.js:104 5.4/constants.js:104
+#. 3.4/constants.js:94 5.4/constants.js:94
 msgid "Full Moon"
 msgstr "Telihold"
 
-#. 3.4/constants.js:105 5.4/constants.js:105
+#. 3.4/constants.js:95 5.4/constants.js:95
 msgid "Waning Gibbous"
 msgstr "Csökkenő domború"
 
-#. 3.4/constants.js:106 5.4/constants.js:106
+#. 3.4/constants.js:96 5.4/constants.js:96
 msgid "Last Quarter"
 msgstr "Utolsó negyed"
 
-#. 3.4/constants.js:107 5.4/constants.js:107
+#. 3.4/constants.js:97 5.4/constants.js:97
 msgid "Waning Crescent"
 msgstr "Csökkenő sarló"
 
-#. 3.4/constants.js:111 5.4/constants.js:111
+#. 3.4/constants.js:101 5.4/constants.js:101
 msgid "New"
 msgstr "Új"
 
-#. 3.4/constants.js:112 3.4/constants.js:114 5.4/constants.js:112
-#. 5.4/constants.js:114
+#. 3.4/constants.js:102 3.4/constants.js:104 5.4/constants.js:102
+#. 5.4/constants.js:104
 msgid "Half"
 msgstr "Fél"
 
-#. 3.4/constants.js:113 5.4/constants.js:113
+#. 3.4/constants.js:103 5.4/constants.js:103
 msgid "Full"
 msgstr "Teli"
 
-#. 3.4/constants.js:170 5.4/constants.js:170
+#. 3.4/constants.js:160 5.4/constants.js:160
 msgid "Clear"
 msgstr "Tiszta"
 
-#. 3.4/constants.js:171 3.4/constants.js:172 5.4/constants.js:171
-#. 5.4/constants.js:172
+#. 3.4/constants.js:161 3.4/constants.js:162 5.4/constants.js:161
+#. 5.4/constants.js:162
 msgid "Cloudy"
 msgstr "Felhős"
 
-#. 3.4/constants.js:173 5.4/constants.js:173
+#. 3.4/constants.js:163 5.4/constants.js:163
 msgid "Fog"
 msgstr "Köd"
 
-#. 3.4/constants.js:174 3.4/constants.js:175 3.4/weatherapi_source.js:154
-#. 5.4/constants.js:174 5.4/constants.js:175 5.4/weatherapi_source.js:154
+#. 3.4/constants.js:164 3.4/constants.js:165 3.4/weatherapi_source.js:154
+#. 5.4/constants.js:164 5.4/constants.js:165 5.4/weatherapi_source.js:154
 msgid "Rain"
 msgstr "Eső"
 
-#. 3.4/constants.js:176 5.4/constants.js:176
+#. 3.4/constants.js:166 5.4/constants.js:166
 msgid "Storm"
 msgstr "Vihar"
 
-#. 3.4/constants.js:177 5.4/constants.js:177
+#. 3.4/constants.js:167 5.4/constants.js:167
 msgid ""
 "Cold\n"
 "precip."
@@ -101,11 +101,11 @@ msgstr ""
 "Hideg\n"
 "csapadék."
 
-#. 3.4/desklet.js:149 5.4/desklet.js:149
+#. 3.4/desklet.js:143 5.4/desklet.js:143
 msgid "Date and Time Settings"
 msgstr "Dátum és idő beállítások"
 
-#. 3.4/desklet.js:408 3.4/desklet.js:439 5.4/desklet.js:408 5.4/desklet.js:439
+#. 3.4/desklet.js:400 3.4/desklet.js:431 5.4/desklet.js:400 5.4/desklet.js:431
 msgid "Limit"
 msgstr "Korlát"
 
@@ -113,11 +113,11 @@ msgstr "Korlát"
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-emoji-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-#. 3.4/desklet.js:412 5.4/desklet.js:412
+#. 3.4/desklet.js:404 5.4/desklet.js:404
 msgid "None"
 msgstr "Semmi"
 
-#. 3.4/desklet.js:454 5.4/desklet.js:454
+#. 3.4/desklet.js:446 5.4/desklet.js:446
 msgid ""
 "Right-click\n"
 "to configure!"
@@ -126,35 +126,35 @@ msgstr ""
 "a konfiguráláshoz!"
 
 #. metadata.json->name
-#. 3.4/desklet.js:507 5.4/desklet.js:507
+#. 3.4/desklet.js:499 5.4/desklet.js:499
 msgid "Moonlight Clock"
 msgstr "Holdfény Óra"
 
-#. 3.4/wallclock_source.js:13 5.4/wallclock_source.js:13
+#. 3.4/wallclock_source.js:14 5.4/wallclock_source.js:14
 msgid "Late Night"
 msgstr "Késő este"
 
-#. 3.4/wallclock_source.js:16 5.4/wallclock_source.js:16
+#. 3.4/wallclock_source.js:17 5.4/wallclock_source.js:17
 msgid "Early Morning"
 msgstr "Kora reggel"
 
-#. 3.4/wallclock_source.js:19 5.4/wallclock_source.js:19
+#. 3.4/wallclock_source.js:20 5.4/wallclock_source.js:20
 msgid "Morning"
 msgstr "Reggel"
 
-#. 3.4/wallclock_source.js:22 5.4/wallclock_source.js:22
+#. 3.4/wallclock_source.js:23 5.4/wallclock_source.js:23
 msgid "Daytime"
 msgstr "Nappal"
 
-#. 3.4/wallclock_source.js:25 5.4/wallclock_source.js:25
+#. 3.4/wallclock_source.js:26 5.4/wallclock_source.js:26
 msgid "Afternoon"
 msgstr "Délután"
 
-#. 3.4/wallclock_source.js:28 5.4/wallclock_source.js:28
+#. 3.4/wallclock_source.js:29 5.4/wallclock_source.js:29
 msgid "Evening"
 msgstr "Este"
 
-#. 3.4/wallclock_source.js:125 5.4/wallclock_source.js:125
+#. 3.4/wallclock_source.js:126 5.4/wallclock_source.js:126
 msgid "Today"
 msgstr "Ma"
 
@@ -191,44 +191,44 @@ msgstr "Betöltés"
 msgid "Save"
 msgstr "mentés"
 
-#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
+#. 3.4/settingsWidgets.py:128 5.4/settingsWidgets.py:128
 msgid "Enabled"
 msgstr "Bekapcsolva"
 
-#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
+#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
 msgid "Persistent"
 msgstr "Kitartó"
 
-#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
+#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
 msgid "Date"
 msgstr "Dátum"
 
-#. 3.4/settingsWidgets.py:132 5.4/settingsWidgets.py:132
+#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
 msgid "Name"
 msgstr "Név"
 
-#. 3.4/settingsWidgets.py:233 3.4/settingsWidgets.py:329
-#. 5.4/settingsWidgets.py:233 5.4/settingsWidgets.py:329
+#. 3.4/settingsWidgets.py:232 3.4/settingsWidgets.py:328
+#. 5.4/settingsWidgets.py:232 5.4/settingsWidgets.py:328
 msgid "Add new entry"
 msgstr "Új bejegyzés hozzáadása"
 
-#. 3.4/settingsWidgets.py:237 5.4/settingsWidgets.py:237
+#. 3.4/settingsWidgets.py:236 5.4/settingsWidgets.py:236
 msgid "Remove selected entry"
 msgstr "A kiválasztott bejegyzés eltávolítása"
 
-#. 3.4/settingsWidgets.py:242 5.4/settingsWidgets.py:242
+#. 3.4/settingsWidgets.py:241 5.4/settingsWidgets.py:241
 msgid "Edit selected entry"
 msgstr "A kiválasztott bejegyzés szerkesztése"
 
-#. 3.4/settingsWidgets.py:247 5.4/settingsWidgets.py:247
+#. 3.4/settingsWidgets.py:246 5.4/settingsWidgets.py:246
 msgid "Move selected entry up"
 msgstr "A kiválasztott bejegyzés mozgatása felfelé"
 
-#. 3.4/settingsWidgets.py:252 5.4/settingsWidgets.py:252
+#. 3.4/settingsWidgets.py:251 5.4/settingsWidgets.py:251
 msgid "Move selected entry down"
 msgstr "A kiválasztott bejegyzés mozgatása lefelé"
 
-#. 3.4/settingsWidgets.py:331 5.4/settingsWidgets.py:331
+#. 3.4/settingsWidgets.py:330 5.4/settingsWidgets.py:330
 msgid "Edit entry"
 msgstr "Bejegyzés szerkesztése"
 
@@ -673,7 +673,8 @@ msgstr "Hőmérséklet °F (W)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-msgid "Full moon countdown (C?)"
+#, fuzzy
+msgid "Moon countdown (C?)"
 msgstr "Telihold visszaszámlálás (C?)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
@@ -690,6 +691,31 @@ msgstr "Felirat megjelenítése"
 #. 5.4->settings-schema.json->bottom-show-secondary-countdowns->description
 msgid "Show more countdowns in secondary text (D)"
 msgstr "További visszaszámlálás megjelenítése a másodlagos szövegben (D)"
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "Select moon phases"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌑"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌓"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌕"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌗"
+msgstr ""
 
 #. 3.4->settings-schema.json->custom-countdown-list-label->description
 #. 5.4->settings-schema.json->custom-countdown-list-label->description

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/it.po
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/it.po
@@ -675,8 +675,8 @@ msgstr "Temperatura °F (W)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-msgid "Full moon countdown (C?)"
-msgstr "Conto alla rivescia: Luna piena (C?)"
+msgid "Moon countdown (C?)"
+msgstr "Conto alla rivescia: Luna (C?)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
@@ -692,6 +692,31 @@ msgstr "Didascalia mostrata"
 #. 5.4->settings-schema.json->bottom-show-secondary-countdowns->description
 msgid "Show more countdowns in secondary text (D)"
 msgstr "Mostra più conti alla rovescia nel testo secondario (D)"
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "Select moon phases"
+msgstr "Seleziona fasi lunari"
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌑"
+msgstr "🌑"
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌓"
+msgstr "🌓"
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌕"
+msgstr "🌕"
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌗"
+msgstr "🌗"
 
 #. 3.4->settings-schema.json->custom-countdown-list-label->description
 #. 5.4->settings-schema.json->custom-countdown-list-label->description

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/moonlight-clock@torchipeppo.pot
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/moonlight-clock@torchipeppo.pot
@@ -630,7 +630,7 @@ msgstr ""
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-msgid "Full moon countdown (C?)"
+msgid "Moon countdown (C?)"
 msgstr ""
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
@@ -646,6 +646,31 @@ msgstr ""
 #. 3.4->settings-schema.json->bottom-show-secondary-countdowns->description
 #. 5.4->settings-schema.json->bottom-show-secondary-countdowns->description
 msgid "Show more countdowns in secondary text (D)"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "Select moon phases"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌑"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌓"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌕"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌗"
 msgstr ""
 
 #. 3.4->settings-schema.json->custom-countdown-list-label->description

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/nl.po
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/nl.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: moonlight-clock@torchipeppo 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-08 19:15+0100\n"
+"POT-Creation-Date: 2025-10-22 18:32+0200\n"
 "PO-Revision-Date: 2025-05-16 18:31+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -20,78 +20,78 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 3.4/constants.js:43 5.4/constants.js:43
+#. 3.4/constants.js:45 5.4/constants.js:45
 msgid "Next"
 msgstr "Volgende"
 
-#. 3.4/constants.js:100 5.4/constants.js:100
+#. 3.4/constants.js:90 5.4/constants.js:90
 msgid "New Moon"
 msgstr "Nieuwe maan"
 
-#. 3.4/constants.js:101 5.4/constants.js:101
+#. 3.4/constants.js:91 5.4/constants.js:91
 msgid "Waxing Crescent"
 msgstr "Wassende maansikkel"
 
-#. 3.4/constants.js:102 5.4/constants.js:102
+#. 3.4/constants.js:92 5.4/constants.js:92
 msgid "First Quarter"
 msgstr "Eerste kwartier"
 
-#. 3.4/constants.js:103 5.4/constants.js:103
+#. 3.4/constants.js:93 5.4/constants.js:93
 msgid "Waxing Gibbous"
 msgstr "Wassende maan"
 
-#. 3.4/constants.js:104 5.4/constants.js:104
+#. 3.4/constants.js:94 5.4/constants.js:94
 msgid "Full Moon"
 msgstr "Volle maan"
 
-#. 3.4/constants.js:105 5.4/constants.js:105
+#. 3.4/constants.js:95 5.4/constants.js:95
 msgid "Waning Gibbous"
 msgstr "Afnemende maan"
 
-#. 3.4/constants.js:106 5.4/constants.js:106
+#. 3.4/constants.js:96 5.4/constants.js:96
 msgid "Last Quarter"
 msgstr "Laatste kwartier"
 
-#. 3.4/constants.js:107 5.4/constants.js:107
+#. 3.4/constants.js:97 5.4/constants.js:97
 msgid "Waning Crescent"
 msgstr "Afnemende maansikkel"
 
-#. 3.4/constants.js:111 5.4/constants.js:111
+#. 3.4/constants.js:101 5.4/constants.js:101
 msgid "New"
 msgstr "Nieuw"
 
-#. 3.4/constants.js:112 3.4/constants.js:114 5.4/constants.js:112
-#. 5.4/constants.js:114
+#. 3.4/constants.js:102 3.4/constants.js:104 5.4/constants.js:102
+#. 5.4/constants.js:104
 msgid "Half"
 msgstr "Half"
 
-#. 3.4/constants.js:113 5.4/constants.js:113
+#. 3.4/constants.js:103 5.4/constants.js:103
 msgid "Full"
 msgstr "Vol"
 
-#. 3.4/constants.js:170 5.4/constants.js:170
+#. 3.4/constants.js:160 5.4/constants.js:160
 msgid "Clear"
 msgstr "Helder"
 
-#. 3.4/constants.js:171 3.4/constants.js:172 5.4/constants.js:171
-#. 5.4/constants.js:172
+#. 3.4/constants.js:161 3.4/constants.js:162 5.4/constants.js:161
+#. 5.4/constants.js:162
 msgid "Cloudy"
 msgstr "Bewolkt"
 
-#. 3.4/constants.js:173 5.4/constants.js:173
+#. 3.4/constants.js:163 5.4/constants.js:163
 msgid "Fog"
 msgstr "Mist"
 
-#. 3.4/constants.js:174 3.4/constants.js:175 3.4/weatherapi_source.js:154
-#. 5.4/constants.js:174 5.4/constants.js:175 5.4/weatherapi_source.js:154
+#. 3.4/constants.js:164 3.4/constants.js:165 3.4/weatherapi_source.js:154
+#. 5.4/constants.js:164 5.4/constants.js:165 5.4/weatherapi_source.js:154
 msgid "Rain"
 msgstr "Regen"
 
-#. 3.4/constants.js:176 5.4/constants.js:176
+#. 3.4/constants.js:166 5.4/constants.js:166
 msgid "Storm"
 msgstr "Storm"
 
-#. 3.4/constants.js:177 5.4/constants.js:177
+#. 3.4/constants.js:167 5.4/constants.js:167
 msgid ""
 "Cold\n"
 "precip."
@@ -99,11 +99,11 @@ msgstr ""
 "Koud\n"
 "neerslag"
 
-#. 3.4/desklet.js:149 5.4/desklet.js:149
+#. 3.4/desklet.js:143 5.4/desklet.js:143
 msgid "Date and Time Settings"
 msgstr "Datum- en tijdinstellingen"
 
-#. 3.4/desklet.js:408 3.4/desklet.js:439 5.4/desklet.js:408 5.4/desklet.js:439
+#. 3.4/desklet.js:400 3.4/desklet.js:431 5.4/desklet.js:400 5.4/desklet.js:431
 msgid "Limit"
 msgstr "Limiet"
 
@@ -111,11 +111,11 @@ msgstr "Limiet"
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-emoji-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-#. 3.4/desklet.js:412 5.4/desklet.js:412
+#. 3.4/desklet.js:404 5.4/desklet.js:404
 msgid "None"
 msgstr "Geen"
 
-#. 3.4/desklet.js:454 5.4/desklet.js:454
+#. 3.4/desklet.js:446 5.4/desklet.js:446
 msgid ""
 "Right-click\n"
 "to configure!"
@@ -124,35 +124,35 @@ msgstr ""
 "om te configureren!"
 
 #. metadata.json->name
-#. 3.4/desklet.js:507 5.4/desklet.js:507
+#. 3.4/desklet.js:499 5.4/desklet.js:499
 msgid "Moonlight Clock"
 msgstr "Maanlichtklok"
 
-#. 3.4/wallclock_source.js:13 5.4/wallclock_source.js:13
+#. 3.4/wallclock_source.js:14 5.4/wallclock_source.js:14
 msgid "Late Night"
 msgstr "Late nacht"
 
-#. 3.4/wallclock_source.js:16 5.4/wallclock_source.js:16
+#. 3.4/wallclock_source.js:17 5.4/wallclock_source.js:17
 msgid "Early Morning"
 msgstr "Vroege ochtend"
 
-#. 3.4/wallclock_source.js:19 5.4/wallclock_source.js:19
+#. 3.4/wallclock_source.js:20 5.4/wallclock_source.js:20
 msgid "Morning"
 msgstr "Ochtend"
 
-#. 3.4/wallclock_source.js:22 5.4/wallclock_source.js:22
+#. 3.4/wallclock_source.js:23 5.4/wallclock_source.js:23
 msgid "Daytime"
 msgstr "Overdag"
 
-#. 3.4/wallclock_source.js:25 5.4/wallclock_source.js:25
+#. 3.4/wallclock_source.js:26 5.4/wallclock_source.js:26
 msgid "Afternoon"
 msgstr "Namiddag"
 
-#. 3.4/wallclock_source.js:28 5.4/wallclock_source.js:28
+#. 3.4/wallclock_source.js:29 5.4/wallclock_source.js:29
 msgid "Evening"
 msgstr "Avond"
 
-#. 3.4/wallclock_source.js:125 5.4/wallclock_source.js:125
+#. 3.4/wallclock_source.js:126 5.4/wallclock_source.js:126
 msgid "Today"
 msgstr "Vandaag"
 
@@ -189,44 +189,44 @@ msgstr "Laden"
 msgid "Save"
 msgstr "Opslaan"
 
-#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
+#. 3.4/settingsWidgets.py:128 5.4/settingsWidgets.py:128
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
+#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
 msgid "Persistent"
 msgstr "Persistent"
 
-#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
+#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
 msgid "Date"
 msgstr "Datum"
 
-#. 3.4/settingsWidgets.py:132 5.4/settingsWidgets.py:132
+#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
 msgid "Name"
 msgstr "Naam"
 
-#. 3.4/settingsWidgets.py:233 3.4/settingsWidgets.py:329
-#. 5.4/settingsWidgets.py:233 5.4/settingsWidgets.py:329
+#. 3.4/settingsWidgets.py:232 3.4/settingsWidgets.py:328
+#. 5.4/settingsWidgets.py:232 5.4/settingsWidgets.py:328
 msgid "Add new entry"
 msgstr "Nieuwe invoer toevoegen"
 
-#. 3.4/settingsWidgets.py:237 5.4/settingsWidgets.py:237
+#. 3.4/settingsWidgets.py:236 5.4/settingsWidgets.py:236
 msgid "Remove selected entry"
 msgstr "Geselecteerde invoer verwijderen"
 
-#. 3.4/settingsWidgets.py:242 5.4/settingsWidgets.py:242
+#. 3.4/settingsWidgets.py:241 5.4/settingsWidgets.py:241
 msgid "Edit selected entry"
 msgstr "Geselecteerde invoer bewerken"
 
-#. 3.4/settingsWidgets.py:247 5.4/settingsWidgets.py:247
+#. 3.4/settingsWidgets.py:246 5.4/settingsWidgets.py:246
 msgid "Move selected entry up"
 msgstr "Geselecteerde invoer omhoog verplaatsen"
 
-#. 3.4/settingsWidgets.py:252 5.4/settingsWidgets.py:252
+#. 3.4/settingsWidgets.py:251 5.4/settingsWidgets.py:251
 msgid "Move selected entry down"
 msgstr "Geselecteerde invoer omlaag verplaatsen"
 
-#. 3.4/settingsWidgets.py:331 5.4/settingsWidgets.py:331
+#. 3.4/settingsWidgets.py:330 5.4/settingsWidgets.py:330
 msgid "Edit entry"
 msgstr "Invoer bewerken"
 
@@ -672,7 +672,8 @@ msgstr "Temperatuur °F (W)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-msgid "Full moon countdown (C?)"
+#, fuzzy
+msgid "Moon countdown (C?)"
 msgstr "Volle maan aftellen (C?)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
@@ -689,6 +690,31 @@ msgstr "Onderschriftweergave"
 #. 5.4->settings-schema.json->bottom-show-secondary-countdowns->description
 msgid "Show more countdowns in secondary text (D)"
 msgstr "Toon meer aftellingen in secundaire tekst (D)"
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "Select moon phases"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌑"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌓"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌕"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌗"
+msgstr ""
 
 #. 3.4->settings-schema.json->custom-countdown-list-label->description
 #. 5.4->settings-schema.json->custom-countdown-list-label->description

--- a/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/vi.po
+++ b/moonlight-clock@torchipeppo/files/moonlight-clock@torchipeppo/po/vi.po
@@ -12,7 +12,7 @@ msgstr ""
 "Project-Id-Version: moonlight-clock@torchipeppo 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-03-08 19:15+0100\n"
+"POT-Creation-Date: 2025-10-22 18:32+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -22,88 +22,90 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 3.4/constants.js:43 5.4/constants.js:43
+#. 3.4/constants.js:45 5.4/constants.js:45
 msgid "Next"
 msgstr "Tiếp theo"
 
-#. 3.4/constants.js:100 5.4/constants.js:100
+#. 3.4/constants.js:90 5.4/constants.js:90
 msgid "New Moon"
 msgstr "Trăng non"
 
-#. 3.4/constants.js:101 5.4/constants.js:101
+#. 3.4/constants.js:91 5.4/constants.js:91
 msgid "Waxing Crescent"
 msgstr "Trăng lưỡi liềm đầu tháng"
 
-#. 3.4/constants.js:102 5.4/constants.js:102
+#. 3.4/constants.js:92 5.4/constants.js:92
 msgid "First Quarter"
 msgstr "Trăng bán nguyệt đầu tháng"
 
-#. 3.4/constants.js:103 5.4/constants.js:103
+#. 3.4/constants.js:93 5.4/constants.js:93
 msgid "Waxing Gibbous"
 msgstr "Trăng khuyết đầu tháng"
 
-#. 3.4/constants.js:104 5.4/constants.js:104
+#. 3.4/constants.js:94 5.4/constants.js:94
 msgid "Full Moon"
 msgstr "Trăng tròn"
 
-#. 3.4/constants.js:105 5.4/constants.js:105
+#. 3.4/constants.js:95 5.4/constants.js:95
 msgid "Waning Gibbous"
 msgstr "Trăng khuyết cuối tháng"
 
-#. 3.4/constants.js:106 5.4/constants.js:106
+#. 3.4/constants.js:96 5.4/constants.js:96
 msgid "Last Quarter"
 msgstr "Trăng bán nguyệt cuối tháng"
 
-#. 3.4/constants.js:107 5.4/constants.js:107
+#. 3.4/constants.js:97 5.4/constants.js:97
 msgid "Waning Crescent"
 msgstr "Trăng lưỡi liềm cuối tháng"
 
-#. 3.4/constants.js:111 5.4/constants.js:111
+#. 3.4/constants.js:101 5.4/constants.js:101
 msgid "New"
 msgstr "Mới"
 
-#. 3.4/constants.js:112 3.4/constants.js:114 5.4/constants.js:112
-#. 5.4/constants.js:114
+#. 3.4/constants.js:102 3.4/constants.js:104 5.4/constants.js:102
+#. 5.4/constants.js:104
 msgid "Half"
 msgstr "Nửa"
 
-#. 3.4/constants.js:113 5.4/constants.js:113
+#. 3.4/constants.js:103 5.4/constants.js:103
 msgid "Full"
 msgstr "Đầy"
 
-#. 3.4/constants.js:170 5.4/constants.js:170
+#. 3.4/constants.js:160 5.4/constants.js:160
 msgid "Clear"
 msgstr "Quang đãng"
 
-#. 3.4/constants.js:171 3.4/constants.js:172 5.4/constants.js:171
-#. 5.4/constants.js:172
+#. 3.4/constants.js:161 3.4/constants.js:162 5.4/constants.js:161
+#. 5.4/constants.js:162
 msgid "Cloudy"
 msgstr "Nhiều mây"
 
-#. 3.4/constants.js:173 5.4/constants.js:173
+#. 3.4/constants.js:163 5.4/constants.js:163
 msgid "Fog"
 msgstr "Sương mù"
 
-#. 3.4/constants.js:174 3.4/constants.js:175 3.4/weatherapi_source.js:154
-#. 5.4/constants.js:174 5.4/constants.js:175 5.4/weatherapi_source.js:154
+#. 3.4/constants.js:164 3.4/constants.js:165 3.4/weatherapi_source.js:154
+#. 5.4/constants.js:164 5.4/constants.js:165 5.4/weatherapi_source.js:154
 msgid "Rain"
 msgstr "Mưa"
 
-#. 3.4/constants.js:176 5.4/constants.js:176
+#. 3.4/constants.js:166 5.4/constants.js:166
 msgid "Storm"
 msgstr "Bão"
 
-#. 3.4/constants.js:177 5.4/constants.js:177
+#. 3.4/constants.js:167 5.4/constants.js:167
 msgid ""
 "Cold\n"
 "precip."
-msgstr "Mưa\nlạnh"
+msgstr ""
+"Mưa\n"
+"lạnh"
 
-#. 3.4/desklet.js:149 5.4/desklet.js:149
+#. 3.4/desklet.js:143 5.4/desklet.js:143
 msgid "Date and Time Settings"
 msgstr "Cài đặt Ngày giờ"
 
-#. 3.4/desklet.js:408 3.4/desklet.js:439 5.4/desklet.js:408 5.4/desklet.js:439
+#. 3.4/desklet.js:400 3.4/desklet.js:431 5.4/desklet.js:400 5.4/desklet.js:431
 msgid "Limit"
 msgstr "Giới hạn"
 
@@ -111,46 +113,48 @@ msgstr "Giới hạn"
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-emoji-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-#. 3.4/desklet.js:412 5.4/desklet.js:412
+#. 3.4/desklet.js:404 5.4/desklet.js:404
 msgid "None"
 msgstr "Không"
 
-#. 3.4/desklet.js:454 5.4/desklet.js:454
+#. 3.4/desklet.js:446 5.4/desklet.js:446
 msgid ""
 "Right-click\n"
 "to configure!"
-msgstr "Nhấp chuột phải\nđể cấu hình!"
+msgstr ""
+"Nhấp chuột phải\n"
+"để cấu hình!"
 
 #. metadata.json->name
-#. 3.4/desklet.js:507 5.4/desklet.js:507
+#. 3.4/desklet.js:499 5.4/desklet.js:499
 msgid "Moonlight Clock"
 msgstr "Đồng hồ Moonlight"
 
-#. 3.4/wallclock_source.js:13 5.4/wallclock_source.js:13
+#. 3.4/wallclock_source.js:14 5.4/wallclock_source.js:14
 msgid "Late Night"
 msgstr "Khuya"
 
-#. 3.4/wallclock_source.js:16 5.4/wallclock_source.js:16
+#. 3.4/wallclock_source.js:17 5.4/wallclock_source.js:17
 msgid "Early Morning"
 msgstr "Sáng sớm"
 
-#. 3.4/wallclock_source.js:19 5.4/wallclock_source.js:19
+#. 3.4/wallclock_source.js:20 5.4/wallclock_source.js:20
 msgid "Morning"
 msgstr "Buổi sáng"
 
-#. 3.4/wallclock_source.js:22 5.4/wallclock_source.js:22
+#. 3.4/wallclock_source.js:23 5.4/wallclock_source.js:23
 msgid "Daytime"
 msgstr "Ban ngày"
 
-#. 3.4/wallclock_source.js:25 5.4/wallclock_source.js:25
+#. 3.4/wallclock_source.js:26 5.4/wallclock_source.js:26
 msgid "Afternoon"
 msgstr "Buổi chiều"
 
-#. 3.4/wallclock_source.js:28 5.4/wallclock_source.js:28
+#. 3.4/wallclock_source.js:29 5.4/wallclock_source.js:29
 msgid "Evening"
 msgstr "Buổi tối"
 
-#. 3.4/wallclock_source.js:125 5.4/wallclock_source.js:125
+#. 3.4/wallclock_source.js:126 5.4/wallclock_source.js:126
 msgid "Today"
 msgstr "Hôm nay"
 
@@ -158,13 +162,17 @@ msgstr "Hôm nay"
 msgid ""
 "No network,\n"
 "retrying..."
-msgstr "Không có mạng,\nđang thử lại..."
+msgstr ""
+"Không có mạng,\n"
+"đang thử lại..."
 
 #. 3.4/weatherapi_source.js:105 5.4/weatherapi_source.js:105
 msgid ""
 "Error: see log\n"
 "Super + L"
-msgstr "Lỗi: xem nhật ký\nSuper + L"
+msgstr ""
+"Lỗi: xem nhật ký\n"
+"Super + L"
 
 #. 3.4/weatherapi_source.js:157 5.4/weatherapi_source.js:157
 msgid "Temp"
@@ -183,44 +191,44 @@ msgstr "Tải"
 msgid "Save"
 msgstr "Lưu"
 
-#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
+#. 3.4/settingsWidgets.py:128 5.4/settingsWidgets.py:128
 msgid "Enabled"
 msgstr "Đã bật"
 
-#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
+#. 3.4/settingsWidgets.py:129 5.4/settingsWidgets.py:129
 msgid "Persistent"
 msgstr "Liên tục"
 
-#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
+#. 3.4/settingsWidgets.py:130 5.4/settingsWidgets.py:130
 msgid "Date"
 msgstr "Ngày"
 
-#. 3.4/settingsWidgets.py:132 5.4/settingsWidgets.py:132
+#. 3.4/settingsWidgets.py:131 5.4/settingsWidgets.py:131
 msgid "Name"
 msgstr "Tên"
 
-#. 3.4/settingsWidgets.py:233 3.4/settingsWidgets.py:329
-#. 5.4/settingsWidgets.py:233 5.4/settingsWidgets.py:329
+#. 3.4/settingsWidgets.py:232 3.4/settingsWidgets.py:328
+#. 5.4/settingsWidgets.py:232 5.4/settingsWidgets.py:328
 msgid "Add new entry"
 msgstr "Thêm mục mới"
 
-#. 3.4/settingsWidgets.py:237 5.4/settingsWidgets.py:237
+#. 3.4/settingsWidgets.py:236 5.4/settingsWidgets.py:236
 msgid "Remove selected entry"
 msgstr "Xóa mục đã chọn"
 
-#. 3.4/settingsWidgets.py:242 5.4/settingsWidgets.py:242
+#. 3.4/settingsWidgets.py:241 5.4/settingsWidgets.py:241
 msgid "Edit selected entry"
 msgstr "Sửa mục đã chọn"
 
-#. 3.4/settingsWidgets.py:247 5.4/settingsWidgets.py:247
+#. 3.4/settingsWidgets.py:246 5.4/settingsWidgets.py:246
 msgid "Move selected entry up"
 msgstr "Di chuyển mục đã chọn lên"
 
-#. 3.4/settingsWidgets.py:252 5.4/settingsWidgets.py:252
+#. 3.4/settingsWidgets.py:251 5.4/settingsWidgets.py:251
 msgid "Move selected entry down"
 msgstr "Di chuyển mục đã chọn xuống"
 
-#. 3.4/settingsWidgets.py:331 5.4/settingsWidgets.py:331
+#. 3.4/settingsWidgets.py:330 5.4/settingsWidgets.py:330
 msgid "Edit entry"
 msgstr "Sửa mục"
 
@@ -228,13 +236,17 @@ msgstr "Sửa mục"
 msgid ""
 "An aesthetic and customizable desklet that can function as clock, weather "
 "display, and/or tracker of important dates. Based on Persona 3."
-msgstr "Một desklet thẩm mỹ và có thể tùy chỉnh, có chức năng như đồng hồ, hiển thị thời tiết và/hoặc theo dõi ngày quan trọng. Dựa trên Persona 3"
+msgstr ""
+"Một desklet thẩm mỹ và có thể tùy chỉnh, có chức năng như đồng hồ, hiển thị "
+"thời tiết và/hoặc theo dõi ngày quan trọng. Dựa trên Persona 3"
 
 #. metadata.json->comments
 msgid ""
 "Best placed in the top right corner on the screen. Use the \"offset\" "
 "configuration for precise alignment."
-msgstr "Nên đặt ở góc trên bên phải màn hình. Sử dụng cấu hình \"offset\" để căn chỉnh chính xác"
+msgstr ""
+"Nên đặt ở góc trên bên phải màn hình. Sử dụng cấu hình \"offset\" để căn "
+"chỉnh chính xác"
 
 #. 3.4->settings-schema.json->global-page->title
 #. 5.4->settings-schema.json->global-page->title
@@ -337,7 +349,9 @@ msgstr "Tải cấu hình"
 msgid ""
 "Set these offsets with respect to your desklet grid so that this fits "
 "precisely into your top right corner."
-msgstr "Đặt các giá trị offset này so với lưới desklet của bạn để nó vừa khít với góc trên bên phải"
+msgstr ""
+"Đặt các giá trị offset này so với lưới desklet của bạn để nó vừa khít với "
+"góc trên bên phải"
 
 #. 3.4->settings-schema.json->global-h-offset->description
 #. 5.4->settings-schema.json->global-h-offset->description
@@ -459,7 +473,8 @@ msgstr "Đảo ngược màu hàng dưới"
 #. 5.4->settings-schema.json->global-color-invert-bottom->tooltip
 msgid ""
 "May be useful if the bottom caption doesn't stand out against your background"
-msgstr "Có thể hữu ích nếu chú thích hàng dưới không nổi bật so với nền của bạn"
+msgstr ""
+"Có thể hữu ích nếu chú thích hàng dưới không nổi bật so với nền của bạn"
 
 #. 3.4->settings-schema.json->global-color-use-highlight->description
 #. 5.4->settings-schema.json->global-color-use-highlight->description
@@ -469,7 +484,8 @@ msgstr "Làm nổi bật hiển thị số hàng dưới"
 #. 3.4->settings-schema.json->global-color-use-highlight->tooltip
 #. 5.4->settings-schema.json->global-color-use-highlight->tooltip
 msgid "Affects: rain chance display, temperature display, countdown displays"
-msgstr "Ảnh hưởng: hiển thị xác suất mưa, hiển thị nhiệt độ, hiển thị đếm ngược"
+msgstr ""
+"Ảnh hưởng: hiển thị xác suất mưa, hiển thị nhiệt độ, hiển thị đếm ngược"
 
 #. 3.4->settings-schema.json->top-format->description
 #. 3.4->settings-schema.json->middle-format->description
@@ -484,7 +500,10 @@ msgid ""
 "This uses standard strftime, with the addition of the %! specifier to show "
 "an approximate phase of the day (e.g. Morning, Afternoon, Evening, ...). "
 "Leave empty to show a default date according to your locale and settings."
-msgstr "Sử dụng strftime chuẩn, với bổ sung %! để hiển thị khoảng thời gian trong ngày (ví dụ: Sáng, Chiều, Tối, ...). Để trống để hiển thị ngày mặc định theo ngôn ngữ và cài đặt của bạn"
+msgstr ""
+"Sử dụng strftime chuẩn, với bổ sung %! để hiển thị khoảng thời gian trong "
+"ngày (ví dụ: Sáng, Chiều, Tối, ...). Để trống để hiển thị ngày mặc định theo "
+"ngôn ngữ và cài đặt của bạn"
 
 #. 3.4->settings-schema.json->top-font->description
 #. 3.4->settings-schema.json->middle-font->description
@@ -503,7 +522,8 @@ msgstr "Phông chữ"
 #. 5.4->settings-schema.json->bottom-caption-v-offset->tooltip
 msgid ""
 "Can help conpensate for the varying vertical alignment of different fonts."
-msgstr "Có thể giúp bù đắp cho sự căn chỉnh dọc khác nhau của các phông chữ khác nhau"
+msgstr ""
+"Có thể giúp bù đắp cho sự căn chỉnh dọc khác nhau của các phông chữ khác nhau"
 
 #. 3.4->settings-schema.json->top-weekday->description
 #. 5.4->settings-schema.json->top-weekday->description
@@ -516,7 +536,10 @@ msgid ""
 "This uses standard strftime, with the addition of the %! specifier to show "
 "an approximate phase of the day (e.g. Morning, Afternoon, Evening, ...). "
 "Leave empty to show a default clock according to your locale and settings."
-msgstr "Sử dụng strftime chuẩn, với bổ sung %! để hiển thị khoảng thời gian trong ngày (ví dụ: Sáng, Chiều, Tối, ...). Để trống để hiển thị đồng hồ mặc định theo ngôn ngữ và cài đặt của bạn"
+msgstr ""
+"Sử dụng strftime chuẩn, với bổ sung %! để hiển thị khoảng thời gian trong "
+"ngày (ví dụ: Sáng, Chiều, Tối, ...). Để trống để hiển thị đồng hồ mặc định "
+"theo ngôn ngữ và cài đặt của bạn"
 
 #. 3.4->settings-schema.json->middle-shadow->description
 #. 3.4->settings-schema.json->bottom-caption-shadow->description
@@ -542,7 +565,13 @@ msgid ""
 "master/lunar_calendar_generation for instructions.\n"
 "(D) - You must provide one or more important dates to count down to in the "
 "\"Data\" page."
-msgstr "(W) - Cần có khóa WeatherAPI hợp lệ. Truy cập trang \"Dữ liệu\" để bật nó\n(C?) - TÙY CHỌN: độ chính xác có thể được cải thiện bằng cách tạo lịch âm địa phương. Xem https://github.com/torchipeppo/p3-clock-for-cinnamon/tree/master/lunar_calendar_generation để biết hướng dẫn\n(D) - Bạn phải cung cấp một hoặc nhiều ngày quan trọng để đếm ngược trong trang \"Dữ liệu\""
+msgstr ""
+"(W) - Cần có khóa WeatherAPI hợp lệ. Truy cập trang \"Dữ liệu\" để bật nó\n"
+"(C?) - TÙY CHỌN: độ chính xác có thể được cải thiện bằng cách tạo lịch âm "
+"địa phương. Xem https://github.com/torchipeppo/p3-clock-for-cinnamon/tree/"
+"master/lunar_calendar_generation để biết hướng dẫn\n"
+"(D) - Bạn phải cung cấp một hoặc nhiều ngày quan trọng để đếm ngược trong "
+"trang \"Dữ liệu\""
 
 #. 3.4->settings-schema.json->wapi-help->description
 #. 5.4->settings-schema.json->wapi-help->description
@@ -550,7 +579,10 @@ msgid ""
 "To access weather data from WeatherAPI, an API key is required. Sign up on "
 "weatherapi.com to get one. Be mindful of your request budget when setting "
 "the update frequency or manually requesting updates."
-msgstr "Để truy cập dữ liệu thời tiết từ WeatherAPI, cần có khóa API. Đăng ký trên weatherapi.com để lấy một khóa. Hãy lưu ý đến hạn mức yêu cầu của bạn khi đặt tần suất cập nhật hoặc yêu cầu cập nhật thủ công"
+msgstr ""
+"Để truy cập dữ liệu thời tiết từ WeatherAPI, cần có khóa API. Đăng ký trên "
+"weatherapi.com để lấy một khóa. Hãy lưu ý đến hạn mức yêu cầu của bạn khi "
+"đặt tần suất cập nhật hoặc yêu cầu cập nhật thủ công"
 
 #. 3.4->settings-schema.json->wapi-enable->description
 #. 5.4->settings-schema.json->wapi-enable->description
@@ -578,7 +610,10 @@ msgid ""
 "Enter your location name (e.g. \"Tokyo\"), your coordinates (e.g. "
 "\"123.45,98.765\"), or \"auto:ip\" for automatic lookup based on your IP "
 "address."
-msgstr "Nhập tên vị trí của bạn (ví dụ: \"Tokyo\"), tọa độ của bạn (ví dụ: \"123.45,98.765\"), hoặc \"auto:ip\" để tra cứu tự động dựa trên địa chỉ IP của bạn"
+msgstr ""
+"Nhập tên vị trí của bạn (ví dụ: \"Tokyo\"), tọa độ của bạn (ví dụ: "
+"\"123.45,98.765\"), hoặc \"auto:ip\" để tra cứu tự động dựa trên địa chỉ IP "
+"của bạn"
 
 #. 3.4->settings-schema.json->wapi-update-period-minutes->options
 #. 5.4->settings-schema.json->wapi-update-period-minutes->options
@@ -631,7 +666,8 @@ msgstr "Nhiệt độ °F (W)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
 #. 5.4->settings-schema.json->bottom-caption-type->options
-msgid "Full moon countdown (C?)"
+#, fuzzy
+msgid "Moon countdown (C?)"
 msgstr "Đếm ngược trăng tròn (C?)"
 
 #. 3.4->settings-schema.json->bottom-caption-type->options
@@ -649,6 +685,31 @@ msgstr "Hiển thị chú thích"
 msgid "Show more countdowns in secondary text (D)"
 msgstr "Hiển thị thêm đếm ngược trong văn bản phụ (D)"
 
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "Select moon phases"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌑"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌓"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌕"
+msgstr ""
+
+#. 3.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+#. 5.4->settings-schema.json->bottom-moon-countdown-selection->columns->title
+msgid "🌗"
+msgstr ""
+
 #. 3.4->settings-schema.json->custom-countdown-list-label->description
 #. 5.4->settings-schema.json->custom-countdown-list-label->description
 msgid ""
@@ -659,7 +720,13 @@ msgid ""
 "Disable dates to skip them.\n"
 "Dates set in the past are also skipped unless they are \"persistent\".\n"
 "\n"
-msgstr "Nhập một hoặc nhiều ngày để đếm ngược khi chọn \"Đếm ngược tùy chỉnh\" (1 ngày) và/hoặc \"Hiển thị thêm đếm ngược trong văn bản phụ\" (tối đa 2 ngày bổ sung)\nThứ tự trong danh sách đại diện cho thứ tự ưu tiên của các ngày\nVô hiệu hóa ngày để bỏ qua chúng\nCác ngày đặt trong quá khứ cũng sẽ bị bỏ qua trừ khi chúng \"liên tục\"\n"
+msgstr ""
+"Nhập một hoặc nhiều ngày để đếm ngược khi chọn \"Đếm ngược tùy chỉnh\" (1 "
+"ngày) và/hoặc \"Hiển thị thêm đếm ngược trong văn bản phụ\" (tối đa 2 ngày "
+"bổ sung)\n"
+"Thứ tự trong danh sách đại diện cho thứ tự ưu tiên của các ngày\n"
+"Vô hiệu hóa ngày để bỏ qua chúng\n"
+"Các ngày đặt trong quá khứ cũng sẽ bị bỏ qua trừ khi chúng \"liên tục\"\n"
 
 #. 3.4->settings-schema.json->save-help->description
 #. 5.4->settings-schema.json->save-help->description
@@ -670,7 +737,14 @@ msgid ""
 "- content (including date-time format strings and bottom row selections),\n"
 "- countdown dates.\n"
 "Does NOT correspond to a full export of the configuration."
-msgstr "Nhấp vào nút bên dưới để lưu các cài đặt sau vào tập tin JSON:\n- bảng màu,\n- kiểu văn bản (bao gồm lựa chọn phông chữ, độ lệch bóng và kích thước emoji),\n- nội dung (bao gồm chuỗi định dạng ngày giờ và lựa chọn hàng dưới),\n- ngày đếm ngược\nKHÔNG tương ứng với xuất toàn bộ cấu hình"
+msgstr ""
+"Nhấp vào nút bên dưới để lưu các cài đặt sau vào tập tin JSON:\n"
+"- bảng màu,\n"
+"- kiểu văn bản (bao gồm lựa chọn phông chữ, độ lệch bóng và kích thước "
+"emoji),\n"
+"- nội dung (bao gồm chuỗi định dạng ngày giờ và lựa chọn hàng dưới),\n"
+"- ngày đếm ngược\n"
+"KHÔNG tương ứng với xuất toàn bộ cấu hình"
 
 #. 3.4->settings-schema.json->save-button->description
 #. 5.4->settings-schema.json->save-button->description
@@ -684,7 +758,11 @@ msgid ""
 "below to select a file to load.\n"
 "WARNING: the selected settings will be overwritten, and their original "
 "values will be lost! Unselected settings will be left untouched."
-msgstr "Chọn tùy chọn nào để tải từ bản lưu trước đó, sau đó nhấp vào nút bên dưới để chọn tập tin để tải\nCẢNH BÁO: các cài đặt được chọn sẽ bị ghi đè và giá trị gốc của chúng sẽ bị mất! Các cài đặt không được chọn sẽ được giữ nguyên"
+msgstr ""
+"Chọn tùy chọn nào để tải từ bản lưu trước đó, sau đó nhấp vào nút bên dưới "
+"để chọn tập tin để tải\n"
+"CẢNH BÁO: các cài đặt được chọn sẽ bị ghi đè và giá trị gốc của chúng sẽ bị "
+"mất! Các cài đặt không được chọn sẽ được giữ nguyên"
 
 #. 3.4->settings-schema.json->load-colors->description
 #. 5.4->settings-schema.json->load-colors->description


### PR DESCRIPTION
Allows users of the "Full moon countdown" mode to select which moon phase(s) to count down to. It is now possible to select full, new, and/or either of the other quarters, and the widget will count down to the closest selected phase in the future.

The user @skelletime from the Cinnamon Spices comments may be glad to hear that I surprisingly found an elegant way to implement the feature they originally described without complicating the code or the settings too much.

Regarding translations, one line has become "fuzzy", as "Full moon countdown" was changed to a simple "Moon countdown" to reflect the change to selectable phases. I have already updated the Italian translation.