### PR TITLE
test-spice: Added option to replace uuid to devtest-uuid in copied desklet.js

### DIFF
--- a/test-spice
+++ b/test-spice
@@ -48,11 +48,10 @@ def copy_xlet(uuid, change_uuid=False):
 
         if change_uuid:
             desklet_js_file = f'{dev_dest}/desklet.js'
-            with open(desklet_js_file, 'r') as file:
+            with open(desklet_js_file, 'r+') as file:
                 js_code = file.read()
-                
-            js_code = js_code.replace(uuid, f"{DEV_PREFIX}{uuid}")
-            with open(desklet_js_file, 'w') as file:
+                file.seek(0)
+                js_code = js_code.replace(uuid, f"{DEV_PREFIX}{uuid}")
                 file.write(js_code)
 
         reload_xlet(f'{DEV_PREFIX}{uuid}')


### PR DESCRIPTION
Hello, I updated the `test-spice` script. I added an option to automatically prepend the `devtest-` prefix inside of the copied `desklet.js` file. 

I made this change because it was annoying me that I had to remove/add the `devtest-` prefix to UUID inside `desklet.js` every time I made a new commit. This is relevant when desklets use some extra files and need to refer to their own directory. I suspect I'm not the only one doing this. 

I'm not sure if I'm allowed to make such changes. Please let me know if not.