### PR TITLE
quicklinks@NotSirius-A: Version 1.3

### DIFF
--- a/quicklinks@NotSirius-A/README.md
+++ b/quicklinks@NotSirius-A/README.md
@@ -25,12 +25,6 @@ You can customize this desklet to your taste. Choose from two layouts a list or 
 - You can add a transparent border to your link to make them look bigger.
 - When you disable desklet decorations you can still grab the desklet by the invisible border around it.
 
-### What can be improved?
-
-* Improve font parsing.
-
-* Unfortunately, the xlet settings API at this moment doesn't support `iconfilechooser` within `list` setting, so icons have to be typed in by name, which is somewhat annoying.
-
 
 ### Remarks
 

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/CHANGELOG.md
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.3] - 09.11.2025
+
+### Added
+- PopupMenuItem: "Add new link", which opens a gtk dialog, when confirmed it adds a new link
+- file `open_add_edit_dialog_gtk.py`
+
+### Changed
+- Improved font parsing
+- Changed desklet name from "Quick Links" to "Quick Links - Launcher" to make it clearer what this desklet does
+- Changed desklet description: added the word "launcher" 
+- Updated `quicklinks@NotSirius-A.pot`
+- Some default visual settings
+- Improved border rendering
+- Minor setting changes
+- Changed "icon-name" setting from string to icon. Why did no one tell me there's an icon data type inside lists!!
+- Updated `README.md`
+
+### Removed
+
+- Bold/italic options, because they are no longer needed
 
 ## [1.2] - 14.10.2025
 

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/metadata.json
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/metadata.json
@@ -1,8 +1,8 @@
 {
     "max-instances": "10",
-    "description": "Customizable quick links panel. Allows you to create beautiful themed desktop shortcuts for your most used folders/commands.",
-    "name": "Quick Links",
-    "version": "1.2",
+    "description": "Customizable quick links launcher panel. Allows you to create beautiful themed desktop shortcuts for your most used folders/commands.",
+    "name": "Quick Links - Launcher",
+    "version": "1.3",
     "uuid": "quicklinks@NotSirius-A",
     "author": "NotSirius-A"
 }

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/open_add_edit_dialog_gtk.py
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/open_add_edit_dialog_gtk.py
@@ -1,0 +1,221 @@
+#!/usr/bin/python3
+
+# This code was copied from https://github.com/linuxmint/cinnamon/blob/master/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
+# I modifed it to work for this desklet
+
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+from xapp.SettingsWidgets import *
+
+
+import os
+import sys
+
+import gettext
+import json
+
+from gi.repository import GLib
+
+# i18n
+gettext.install("cinnamon", "/usr/share/locale")
+
+
+translations = {}
+
+
+VARIABLE_TYPE_MAP = {
+    "string"        :   str,
+    "file"          :   str,
+    "icon"          :   str,
+    "sound"         :   str,
+    "keybinding"    :   str,
+    "integer"       :   int,
+    "float"         :   float,
+    "boolean"       :   bool
+}
+
+CLASS_TYPE_MAP = {
+    "string"        :   Entry,
+    "file"          :   FileChooser,
+    "icon"          :   IconChooser,
+    "integer"       :   SpinButton,
+    "float"         :   SpinButton,
+    "boolean"       :   Switch
+}
+
+PROPERTIES_MAP = {
+    "title"         : "label",
+    "min"           : "mini",
+    "max"           : "maxi",
+    "step"          : "step",
+    "units"         : "units",
+    "select-dir"    : "dir_select",
+    "expand-width"  : "expand_width"
+}
+
+def list_edit_factory(options):
+    kwargs = {}
+    if 'options' in options:
+        kwargs['valtype'] = VARIABLE_TYPE_MAP[options['type']]
+        widget_type = ComboBox
+        options_list = options['options']
+        if isinstance(options_list, dict):
+            kwargs['options'] = [(b, a) for a, b in options_list.items()]
+        else:
+            kwargs['options'] = zip(options_list, options_list)
+    else:
+        widget_type = CLASS_TYPE_MAP[options["type"]]
+    class Widget(widget_type):
+        def __init__(self, **kwargs):
+            super(Widget, self).__init__(**kwargs)
+
+            if self.bind_dir is None:
+                self.connect_widget_handlers()
+
+        def get_range(self):
+            return None
+
+        def set_value(self, value):
+            self.widget_value = value
+
+        def get_value(self):
+            if hasattr(self, "widget_value"):
+                return self.widget_value
+            else:
+                return None
+
+        def set_widget_value(self, value):
+            if self.bind_dir is None:
+                self.widget_value = value
+                self.on_setting_changed()
+            else:
+                if hasattr(self, "bind_object"):
+                    self.bind_object.set_property(self.bind_prop, value)
+                else:
+                    self.content_widget.set_property(self.bind_prop, value)
+
+        def get_widget_value(self):
+            if self.bind_dir is None:
+                try:
+                    return self.widget_value
+                except Exception as e:
+                    return None
+            else:
+                if hasattr(self, "bind_object"):
+                    return self.bind_object.get_property(self.bind_prop)
+                return self.content_widget.get_property(self.bind_prop)
+
+    for prop in options:
+        if prop in PROPERTIES_MAP:
+            kwargs[PROPERTIES_MAP[prop]] = options[prop]
+
+    return Widget(**kwargs)
+
+
+class List(SettingsWidget):
+    bind_dir = None
+
+    def __init__(self, label=None, columns=None, height=200, size_group=None, \
+                 dep_key=None):
+        super(List, self).__init__()
+        self.columns = columns
+
+
+
+    def open_add_edit_dialog(self, info=None):
+        self.window = Gtk.Window()
+        # self.tree.set_translation_domain('cinnamon') # let it translate!
+
+        if info is None:
+            title = _("Add new link")
+        else:
+            title = _("Edit link")
+        dialog = Gtk.Dialog(title, self.window)
+
+        dialog.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OK, Gtk.ResponseType.OK
+        )
+
+        content_area = dialog.get_content_area()
+        content_area.set_margin_right(30)
+        content_area.set_margin_left(30)
+        content_area.set_margin_top(20)
+        content_area.set_margin_bottom(20)
+
+        frame = Gtk.Frame()
+        frame.set_shadow_type(Gtk.ShadowType.IN)
+        frame_style = frame.get_style_context()
+        frame_style.add_class("view")
+        content_area.add(frame)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        frame.add(content)
+
+        widgets = []
+        for i in range(len(self.columns)):
+            if len(widgets) != 0:
+                content.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+            widget = list_edit_factory(self.columns[i])
+            widgets.append(widget)
+
+            settings_box = Gtk.ListBox()
+            settings_box.set_selection_mode(Gtk.SelectionMode.NONE)
+
+            content.pack_start(settings_box, True, True, 0)
+            settings_box.add(widget)
+
+            if info is not None and info[i] is not None:
+                widget.set_widget_value(info[i])
+            elif "default" in self.columns[i]:
+                widget.set_widget_value(self.columns[i]["default"])
+
+
+        content_area.show_all()
+        response = dialog.run()
+
+        if response == Gtk.ResponseType.OK:
+            values = {}
+            for column, widget in zip(self.columns, widgets):
+                values[column["id"]] = widget.get_widget_value()
+
+            dialog.destroy()
+            return values
+
+        dialog.destroy()
+        return {"error": "true"}
+
+
+ 
+if __name__ == "__main__":
+
+    rv = {"error": "true"}
+
+    try:
+        list = List(
+            columns=json.loads(sys.argv[1])
+        )
+        out = list.open_add_edit_dialog()
+        rv = json.dumps(out)
+
+    except Exception as e:
+        # print(e)
+        pass
+
+    print(rv)
+
+    
+    
+    
+# list = List(
+#     columns = [
+#         # {"id": "is-visible", "title": "Display", "type": "boolean", "default": True},
+#         {"id": "name", "title": "Name", "type": "string", "default": "Name"},
+#         {"id": "icon-name", "title": "Icon name", "type": "icon", "default": "folder"},
+#         {"id": "command", "title": "Command", "type": "string", "default": "nemo /"},
+#         {"id": "shell", "title": "Shell", "type": "boolean", "default": True, "align": 0}
+#     ]
+# )

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/po/quicklinks@NotSirius-A.pot
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/po/quicklinks@NotSirius-A.pot
@@ -1,14 +1,14 @@
-# QUICK LINKS
+# QUICK LINKS - LAUNCHER
 # This file is put in the public domain.
 # NotSirius-A, 2025
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: quicklinks@NotSirius-A 1.2\n"
+"Project-Id-Version: quicklinks@NotSirius-A 1.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2025-10-14 20:05+0200\n"
+"POT-Creation-Date: 2025-11-10 11:27+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,7 +17,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. desklet.js:135
+#. desklet.js:127
+msgid "Sorry, this font is not supported, please select a different one."
+msgstr ""
+
+#. desklet.js:128
+msgid " Font: `"
+msgstr ""
+
+#. desklet.js:128
+msgid "` Error: "
+msgstr ""
+
+#. desklet.js:188
 msgid ""
 "No visible\n"
 "links found.\n"
@@ -28,18 +40,26 @@ msgid ""
 "then configure."
 msgstr ""
 
-#. desklet.js:355
+#. desklet.js:412
 msgid "Quick Links: Command parse error: "
+msgstr ""
+
+#. desklet.js:431 open_add_edit_dialog_gtk.py:132
+msgid "Add new link"
+msgstr ""
+
+#. open_add_edit_dialog_gtk.py:134
+msgid "Edit link"
 msgstr ""
 
 #. metadata.json->description
 msgid ""
-"Customizable quick links panel. Allows you to create beautiful themed "
-"desktop shortcuts for your most used folders/commands."
+"Customizable quick links launcher panel. Allows you to create beautiful "
+"themed desktop shortcuts for your most used folders/commands."
 msgstr ""
 
 #. metadata.json->name
-msgid "Quick Links"
+msgid "Quick Links - Launcher"
 msgstr ""
 
 #. settings-schema.json->links-page->title
@@ -56,10 +76,6 @@ msgstr ""
 
 #. settings-schema.json->links-section->title
 msgid "Set up your links here"
-msgstr ""
-
-#. settings-schema.json->iconselect-section->title
-msgid "Find icon names here"
 msgstr ""
 
 #. settings-schema.json->general-section->title
@@ -92,7 +108,6 @@ msgstr ""
 msgid ""
 "Some tips:\n"
 "You can open folders using ex. `nemo <path>` command.\n"
-"If you need to see the output of a command, set the last attribute to true.\n"
 "You can break your links' names into multiple lines by typing \\n where you "
 "want a break.\n"
 "Set `Shell` to enabled if your command only outputs to the console ex. `ls` "
@@ -111,7 +126,7 @@ msgid "Name"
 msgstr ""
 
 #. settings-schema.json->links-list->columns->title
-msgid "Icon name"
+msgid "Icon"
 msgstr ""
 
 #. settings-schema.json->links-list->columns->title
@@ -124,21 +139,6 @@ msgstr ""
 
 #. settings-schema.json->link-update-button->description
 msgid "Update"
-msgstr ""
-
-#. settings-schema.json->icon-picker-label->description
-msgid ""
-"The setting below does not impact the desklet. It's here for convenience.\n"
-"You can browse through icons here and find their names easily."
-msgstr ""
-
-#. settings-schema.json->icon-picker->description
-msgid "Click the icon to browse"
-msgstr ""
-
-#. settings-schema.json->icon-picker->tooltip
-msgid ""
-"Click the icon on the right to browse. This setting is not used anywhere. "
 msgstr ""
 
 #. settings-schema.json->click-type->description
@@ -268,19 +268,11 @@ msgid "Display text"
 msgstr ""
 
 #. settings-schema.json->font->description
-msgid "Font name (choose regular versions)"
+msgid "Link font"
 msgstr ""
 
 #. settings-schema.json->font->tooltip
-msgid "Change font family"
-msgstr ""
-
-#. settings-schema.json->font-bold->description
-msgid "Bold"
-msgstr ""
-
-#. settings-schema.json->font-italic->description
-msgid "Italic"
+msgid "Change font family (some fonts may be broken"
 msgstr ""
 
 #. settings-schema.json->text-color->description

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/settings-schema.json
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/settings-schema.json
@@ -10,8 +10,7 @@
             "type": "page",
             "title": "Links",
             "sections": [
-                "links-section",
-                "iconselect-section"
+                "links-section"
             ]
         },
         "preferences-page": {
@@ -40,14 +39,6 @@
                 "links-bottom-label"
             ]
         },
-        "iconselect-section": {
-            "type": "section",
-            "title": "Find icon names here",
-            "keys": [
-                "icon-picker-label",
-                "icon-picker"
-            ]
-        },
         "general-section": {
             "type": "section",
             "title": "General",
@@ -67,8 +58,8 @@
                 "row-spacing",
                 "column-spacing",
                 "text-align",
-                "bg-color",
                 "transparent-bg",
+                "bg-color",
                 "link-border-width",
                 "link-border-color",
                 "icon-size"
@@ -80,8 +71,6 @@
             "keys": [
                 "font-enabled",
                 "font",
-                "font-bold",
-                "font-italic",
                 "text-color",
                 "text-shadow",
                 "text-shadow-color"
@@ -99,7 +88,7 @@
     },
     "links-top-label": {
         "type": "label",
-        "description": "Each link has 5 attributes you can change:\n - Display: determines whether your link will be shown or not \n - Name that will be displayed\n - Icon name: you can choose any system icon or leave blank\n - Command to be executed when clicked\n - Shell: select if you want the terminal to show up after clicking"
+        "description": "Each link has 5 attributes you can change:\n - Display: determines whether your link will be shown or not \n - Name that will be displayed\n - Icon: you can choose any system icon\n - Command to be executed when clicked\n - Shell: select if you want the terminal to show up after clicking"
     },
     "links-bottom-label": {
         "type": "label",
@@ -110,7 +99,7 @@
         "columns" : [
             {"id": "is-visible", "title": "Display", "type": "boolean", "default": true},
             {"id": "name", "title": "Name", "type": "string", "default": "Name"},
-            {"id": "icon-name", "title": "Icon name", "type": "string", "default": "folder"},
+            {"id": "icon-name", "title": "Icon", "type": "icon", "default": "folder"},
             {"id": "command", "title": "Command", "type": "string", "default": "nemo /"},
             {"id": "shell", "title": "Shell", "type": "boolean", "default": false, "align": 0}
         ],
@@ -194,16 +183,6 @@
         "description": "Update",
         "callback": "on_reset_links_callback"
     },
-    "icon-picker-label": {
-        "type": "label",
-        "description": "The setting below does not impact the desklet. It's here for convenience.\nYou can browse through icons here and find their names easily."
-    },
-    "icon-picker": {
-        "type": "iconfilechooser",
-        "default": "folder",
-        "description": "Click the icon to browse",
-        "tooltip": "Click the icon on the right to browse. This setting is not used anywhere. "
-    },
     "click-type": {
         "type": "combobox",
         "description": "Click type",
@@ -255,7 +234,7 @@
     },
     "row-spacing": {
         "type": "spinbutton",
-        "default": 5,
+        "default": 4,
         "min": 0,
         "max": 25,
         "step": 1,
@@ -264,7 +243,7 @@
     },
     "column-spacing": {
         "type": "spinbutton",
-        "default": 5,
+        "default": 4,
         "min": 0,
         "max": 25,
         "step": 1,
@@ -319,21 +298,9 @@
     },
     "font": {
         "type": "fontchooser",
-        "description": "Font name (choose regular versions)",
+        "description": "Link font",
         "default": "Noto Sans Regular 13",
-        "tooltip": "Change font family",
-        "dependency": "font-enabled"
-    },
-    "font-bold": {
-        "type": "switch",
-        "description": "Bold",
-        "default": false,
-        "dependency": "font-enabled"
-    },
-    "font-italic": {
-        "type": "switch",
-        "description": "Italic",
-        "default": false,
+        "tooltip": "Change font family (some fonts may be broken",
         "dependency": "font-enabled"
     },
     "text-color": {
@@ -345,7 +312,7 @@
     },
     "link-border-width": {
         "type": "spinbutton",
-        "default": 1,
+        "default": 2,
         "min": 0,
         "max": 20,
         "step": 1,
@@ -354,7 +321,7 @@
     },
     "link-border-color": {
         "type": "colorchooser",
-        "default": "rgba(0,0,0,0.0)",
+        "default": "rgba(0,0,0,0.45)",
         "description": "Border color",
         "tooltip": "Set the link border color (Transparent border will add more padding to links).",
         "dependency": "link-border-width>0"

--- a/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/stylesheet.css
+++ b/quicklinks@NotSirius-A/files/quicklinks@NotSirius-A/stylesheet.css
@@ -1,12 +1,12 @@
 .link {
 	color: black;
 	font-weight: 500; /* normal */
-	border-radius: 0.32em;
+	border-radius: 0.4em;
 	padding: 0.2em 0.05em;
 }
 
 .link:hover {
-	border-radius: 0.5em;
+	border-radius: 0.7em;
 	box-shadow: 0px 0px 0px 999px inset rgba(255,255,255,0.15);
 	background-color: rgba(255,255,255,0.1);
 


### PR DESCRIPTION
## [1.3] - 09.11.2025

### Added
- PopupMenuItem: "Add new link", which opens a gtk dialog, when confirmed it adds a new link
- file `open_add_edit_dialog_gtk.py`

### Changed
- Improved font parsing
- Changed desklet name from "Quick Links" to "Quick Links - Launcher" to make it clearer what this desklet does
- Changed desklet description: added the word "launcher" 
- Updated `quicklinks@NotSirius-A.pot`
- Some default visual settings
- Improved border rendering
- Minor setting changes
- Changed "icon-name" setting from string to icon. Why did no one tell me there's an icon data type inside lists!!
- Updated `README.md`

### Removed

- Bold/italic options, because they are no longer needed