### PR TITLE
[commandResult@ZimiZones] remove timer on desklet remove

### DIFF
--- a/commandResult@ZimiZones/files/commandResult@ZimiZones/4.0/desklet.js
+++ b/commandResult@ZimiZones/files/commandResult@ZimiZones/4.0/desklet.js
@@ -194,7 +194,7 @@ MyDesklet.prototype = {
         this._update();
     },
 
-    onDeskletRemoved() {
+    on_desklet_removed() {
         if (this.updateId > 0) {
             Mainloop.source_remove(this.updateId);
         }

--- a/commandResult@ZimiZones/files/commandResult@ZimiZones/desklet.js
+++ b/commandResult@ZimiZones/files/commandResult@ZimiZones/desklet.js
@@ -194,7 +194,7 @@ MyDesklet.prototype = {
         this._update();
     },
 
-    onDeskletRemoved() {
+    on_desklet_removed() {
         if (this.updateId > 0) {
             Mainloop.source_remove(this.updateId);
         }


### PR DESCRIPTION
This was causing spamming of ~/.xsession-errors after desklet was removed.

@ZimiZones 