### PR TITLE
diskspace@schorschii: fixed desklet crashing with null `filesystem` setting

### DIFF
--- a/diskspace@schorschii/files/diskspace@schorschii/desklet.js
+++ b/diskspace@schorschii/files/diskspace@schorschii/desklet.js
@@ -69,6 +69,11 @@ MyDesklet.prototype = {
 			this.random_circle_color_generated = true;
 		}
 
+		// fallback to "/" if filesystem is not defined in the settings
+		if (this.filesystem === undefined || this.filesystem === null) { 
+			this.filesystem = "/"
+		}
+
 		// initialize desklet gui
 		this.setupUI();
 	},


### PR DESCRIPTION
I think this PR closes #1517
@schorschii 

I added a simple `if` to change the value of `this.filesystem` to the default `/` if its not defined/null. 

I think this code will unfortunately trigger an unnecessary callback when changing the value of `this.filesystem`, but it should be fine. Normally I would create another variable to hold the modified value to avoid altering the original or some other weird solution, but I didn't want to change the rest of the code and make big mess for this small issue.