### PR TITLE
TimeAndDate@nightflame: Small CSS update/fix

### DIFF
--- a/TimeAndDate@nightflame/files/TimeAndDate@nightflame/CHANGELOG.md
+++ b/TimeAndDate@nightflame/files/TimeAndDate@nightflame/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.0.1] - 13.12.2025
+
+Small CSS update/fix
+
+### Changed
+
+- `stylesheet.css`
+
+### Fixed
+
+- CSS classes `time-container` and `date-container` were reversed and assigned to wrong elements
 
 ## [2.0] - 05.11.2025
 

--- a/TimeAndDate@nightflame/files/TimeAndDate@nightflame/desklet.js
+++ b/TimeAndDate@nightflame/files/TimeAndDate@nightflame/desklet.js
@@ -164,8 +164,8 @@ MyDesklet.prototype = {
 
 
 
-		let timeLabelContainer =  new St.BoxLayout({vertical:!this.isTwoColumns, style_class: 'date-container'});
-		let dateLabelContainer =  new St.BoxLayout({vertical:!this.isTwoColumns, style_class: 'time-container'});
+		let timeLabelContainer =  new St.BoxLayout({vertical:!this.isTwoColumns, style_class: 'time-container'});
+		let dateLabelContainer =  new St.BoxLayout({vertical:!this.isTwoColumns, style_class: 'date-container'});
 		timeLabelContainer.add(this.timeLabel, {x_fill: false, y_fill: false, x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE});
 		dateLabelContainer.add(this.dateLabel, {x_fill: false, y_fill: false, x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE});
 

--- a/TimeAndDate@nightflame/files/TimeAndDate@nightflame/metadata.json
+++ b/TimeAndDate@nightflame/files/TimeAndDate@nightflame/metadata.json
@@ -2,6 +2,6 @@
     "max-instances": "5",
     "description": "Themeable desklet that displays the time and date. New overhauled version.", 
     "uuid": "TimeAndDate@nightflame", 
-    "version": "2.0",
+    "version": "2.0.1",
     "name": "Time and Date Desklet"
 }

--- a/TimeAndDate@nightflame/files/TimeAndDate@nightflame/stylesheet.css
+++ b/TimeAndDate@nightflame/files/TimeAndDate@nightflame/stylesheet.css
@@ -1,21 +1,24 @@
-.time-container {
-	padding: 0em;
-	margin: 0em;
-}
+/* Please note that your custom CSS configuration (for version 2.0+) may break with future updates. Also, keep in mind that many CSS styles will NOT work here, because they're overridden by the desklet's code (with styles generated based on desklet's configuration). It's not an intended way of customizing your desklets anymore. If possible I'd recommend using the builtin desklet configuration (right click on desklet -> configure), it has many available options and is much easier to use than CSS. */
 
-.date-container {
-	padding: 0em;
-	margin: 0em;
-}
 
-.time-label {
-	padding: 0em;
-	margin: 0em;
-	text-align: center;
+/* .clock-container {
+	background: green; WILL NOT WORK, BECAUSE THE BACKGROUND IS SET BY THE CODE USING DESKLET'S CONFIG 
+} */
+
+/* .time-container {
+	background: red;
+} */
+
+/* .date-container {
+	background: red;
+} */
+
+/* .time-label {
+	background: blue;
+	border: yellow solid 2px;
 }
 
 .date-label {
-	padding: 0em;
-	margin: 0em;
-	text-align: center;
-}
+	background: purple;
+	border: red solid 2px;
+} */


### PR DESCRIPTION
# Question

Hello, I am I correct in assuming that custom CSS styles in `stylesheet.css` will always be overridden by new updates, because entire xlet source code is just replaced by the new version on update installation? I can't check this myself for sure, because all my xlets are up to date now.    

# Changes

## [2.0.1] - 13.12.2025

Small CSS update/fix

### Changed

- `stylesheet.css`

### Fixed

- CSS classes `time-container` and `date-container` were reversed and assigned to wrong elements
