### PR TITLE
timelet@linuxedo.com: fixed clock freezing with 12h setting on 12:00

### DIFF
--- a/timelet@linuxedo.com/files/timelet@linuxedo.com/themes/theme.js
+++ b/timelet@linuxedo.com/files/timelet@linuxedo.com/themes/theme.js
@@ -136,13 +136,11 @@ var Theme = class Theme {
      * localized period abbreviations if there is no translation.
      * 
      * @param {Number} hourIn24 hour in 24h format (0-23)
-     * @returns the translated AM/Noon/PM abbreviations
+     * @returns the translated AM/PM abbreviations
      */
     toPeriod(hourIn24) {
         if (hourIn24 < 12) {
             return _("AM");
-        } else if (hourIn24 == 12 && date.getMinutes() == 0 && date.getSeconds() == 0) {
-            return _("Noon");
         } else {
             return _("PM");
         }


### PR DESCRIPTION
Hello, 
@slgobinath 

This PR closes #1448.

@alejandrolemus already found a solution to this, it feels wrong to take credit, but it's been some time and I don't think they made a PR, so I'm submitting my version of it. 

I've deleted the:
```
} else if (hourIn24 == 12 && date.getMinutes() == 0 && date.getSeconds() == 0) {
    return _("Noon");
} 
```
I think it's not needed, since this adds complexity to this function for almost no reason, as the text "Noon" would be displayed for only 1 second.