### PR TITLE
systemUptime@KopfdesDaemons: Fix frozen uptime in the layout with disabled icon

### DIFF
--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/CHANGELOG.md
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.1] - 09.04.2026
+
+- Fix frozen uptime in the layout with disabled icon
+
 ## [2.0.0] - 06.02.2026
 
 - New features:

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/desklet.js
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/desklet.js
@@ -150,8 +150,10 @@ class MyDesklet extends Desklet.Desklet {
     this._startupValue.set_style(valueStyle);
 
     // Icon
-    this._clockIcon.set_style(iconStyle);
-    this._iconBox.set_style(iconStyle);
+    if (this.showIcon && this._clockIcon && this._iconBox) {
+      this._clockIcon.set_style(iconStyle);
+      this._iconBox.set_style(iconStyle);
+    }
   }
 
   async _fetchUptimeText() {

--- a/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/metadata.json
+++ b/systemUptime@KopfDesDaemons/files/systemUptime@KopfDesDaemons/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "systemUptime@KopfDesDaemons",
   "name": "System Uptime",
   "description": "Displays the current system uptime.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "max-instances": "50",
   "author": "KopfdesDaemons"
 }


### PR DESCRIPTION
A user pointed out on the [Cinnamon website](https://cinnamon-spices.linuxmint.com/desklets/view/70) that the uptime is no longer being updated.

I spent a long time trying to find the problem and reproduce the issue.

The problem should only occur with the layout without the icon, as an attempt is made to set its style even though it does not exist in the UI.

The issue should be resolved.

@CyberWolf2k16 Am I correct in assuming that you used the layout without the icon?