### PR TITLE
Prevents color overriding when the desklet is reloaded

### DIFF
--- a/prayertimes@linworx.org/files/prayertimes@linworx.org/5.8/desklet.js
+++ b/prayertimes@linworx.org/files/prayertimes@linworx.org/5.8/desklet.js
@@ -46,7 +46,6 @@ class MuslimPrayerTimesDesklet extends Desklet.Desklet {
 		this.settings.bind("show_date", "show_date", this.setupUI);
 		this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL, "transparency", "transparency", this.setupUI);
 
-		this.color = 'rgb(255,255,255)';
 		this.city = "Getting location...";
 		this.logger = new Logger.New([metadata.uuid, desklet_id].join('#'));
 		this.today = new Date().getDate();


### PR DESCRIPTION
I noticed that the ``this.color = 'rgb(255,255,255)';`` basically overrides the color from the desklet configuration file. Thus, when I reload the desklet, it sets the current color to ``rgb(255,255,255)`` in the configuration.