### PR TITLE
yfquotes@thegli - weekly and monthly change

### DIFF
--- a/yfquotes@thegli/CHANGELOG.md
+++ b/yfquotes@thegli/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.18.4 - June 18, 2026
+
+Features:
+
+- option to display columns for weekly and monthly change for each stock
+
+
 ### 0.18.3 - March 5, 2026
 
 Features:

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -830,9 +830,9 @@ YahooFinanceQuoteReader.prototype = {
         if (networkSettings.enableCurl) {
             this.retrieveFinanceDataWithCurl(requestUrl, networkSettings, callback);
         } else if (IS_SOUP_2) {
-            this.retrieveFinanceDataWithSoup2(requestUrl, networkSettings, quotesResponseCallback);
+            this.retrieveFinanceDataWithSoup2(requestUrl, networkSettings, callback);
         } else {
-            this.retrieveFinanceDataWithSoup3(requestUrl, networkSettings, quotesResponseCallback);
+            this.retrieveFinanceDataWithSoup3(requestUrl, networkSettings, callback);
         }
     },
 

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -740,7 +740,7 @@ YahooFinanceQuoteReader.prototype = {
         });
     },
 
-    retrieveFinanceData(quoteSymbolsArg, networkSettings, callback) {
+    retrieveFinanceData(quoteSymbolsArg, networkSettings, quoteDisplaySettings, callback) {
         this.quoteUtils.logDebug("retrieveFinanceData");
 
         const _that = this;
@@ -755,15 +755,15 @@ YahooFinanceQuoteReader.prototype = {
 
         //TODO need to check if this works with the after hours feature
 
-        //TODO another way to show this might be instead of percent to be the actual price value at days ago
-
-        //TODO add separate config settings to show week change and/or month change
-
         //TODO have to update the translations
         // - there is a command or instructions in the repo
 
-        //TODO only request history data if settings enabled
         const quotesResponseCallback = (quoteResponse) => {
+            if (!quoteDisplaySettings.showWeeklyChange && !quoteDisplaySettings.showMonthlyChange) {
+                callback.call(_that, quoteResponse);
+                return;
+            }
+
             try {
                 const parsed = JSON.parse(quoteResponse);
 
@@ -1085,10 +1085,13 @@ QuotesTable.prototype = {
             cellContents.push(this.createPercentChangeLabel(quote, settings, marketState));
         }
 
-        //TODO only if enabled
-        cellContents.push(this.createHistoricalPercentChangeLabel(quote, settings, quote.price7DaysAgo, marketState, 'W'));
-        //TODO only if enabled
-        cellContents.push(this.createHistoricalPercentChangeLabel(quote, settings, quote.price1MonthAgo, marketState, 'M'));
+        if (settings.showWeeklyChange) {
+            cellContents.push(this.createHistoricalChangeLabel(quote, settings, quote.price7DaysAgo, marketState, 'weekly'));
+        }
+
+        if (settings.showMonthlyChange) {
+            cellContents.push(this.createHistoricalChangeLabel(quote, settings, quote.price1MonthAgo, marketState, 'monthly'));
+        }
 
         if (settings.tradeTime) {
             cellContents.push(this.createTradeTimeLabel(quote, settings, marketState));
@@ -1257,7 +1260,7 @@ QuotesTable.prototype = {
         });
     },
 
-    createHistoricalPercentChangeLabel(quote, settings, historicalPrice, marketState, prefix) {
+    createHistoricalChangeLabel(quote, settings, historicalPrice, marketState, labelType) {
         const currentPrice = quote.regularMarketPrice;
 
         if (!historicalPrice || !currentPrice) {
@@ -1265,21 +1268,44 @@ QuotesTable.prototype = {
         }
 
         const percentChange = ((currentPrice - historicalPrice) / historicalPrice) * 100;
+        const prefix = 'weekly' === labelType ? 'W' : 'M';
+        const historyChangeType = 'weekly' === labelType ? settings.weeklyChangeType : settings.monthlyChangeType;
+
+        //TODO maybe check createMarketPriceLabel() to add a currency
+        let valueToDisplay = historicalPrice;
+        let valueForTrendCompare = currentPrice;
+        let suffix = '';
+        let uptrendColor = settings.uptrendChangeColor;
+        let downtrendColor = settings.downtrendChangeColor;
+
+        if ('percent' === historyChangeType) {
+            valueToDisplay = percentChange;
+            valueForTrendCompare = 0;
+            suffix = '%';
+        } else if ('absolute' === historyChangeType) {
+            valueToDisplay = currentPrice - historicalPrice;
+            valueForTrendCompare = 0;
+        }
+
+        if ('market_price' === historyChangeType) {
+            uptrendColor = settings.downtrendChangeColor;
+            downtrendColor = settings.uptrendChangeColor;
+        }
 
         let labelColor = settings.fontColor;
 
         if (settings.colorPercentChange) {
-            if (percentChange > 0) {
-                labelColor = settings.uptrendChangeColor;
-            } else if (percentChange < 0) {
-                labelColor = settings.downtrendChangeColor;
+            if (valueToDisplay > valueForTrendCompare) {
+                labelColor = uptrendColor;
+            } else if (valueToDisplay < valueForTrendCompare) {
+                labelColor = downtrendColor;
             } else {
                 labelColor = settings.unchangedTrendColor;
             }
         }
 
         return new St.Label({
-            text: (prefix + this.roundAmount(percentChange, 2, settings.strictRounding) + "%"),
+            text: (prefix + this.roundAmount(valueToDisplay, 2, settings.strictRounding) + suffix),
             style_class: "quotes-number",
             style: this.buildFontStyle(settings, marketState, labelColor)
         });
@@ -1429,6 +1455,7 @@ StockQuoteDesklet.prototype = {
             "customDateFormat", "sortCriteria", "sortDirection", "showChangeIcon", "showQuoteName",
             "useLongQuoteName", "linkQuoteName", "showQuoteSymbol", "linkQuoteSymbol", "showMarketPrice",
             "showCurrencyCode", "showAbsoluteChange", "showPercentChange", "colorPercentChange",
+            "showWeeklyChange", "weeklyChangeType", "showMonthlyChange", "monthlyChangeType",
             "showTradeTime", "includePrePostMarketDataOption", "fontColor", "scaleFontSize", "fontScale",
             "fontStylePrePostMarketData", "uptrendChangeColor", "downtrendChangeColor", "unchangedTrendColor"];
         const dataFetchSettings = ["delayMinutes"];
@@ -1449,6 +1476,9 @@ StockQuoteDesklet.prototype = {
             // no callback, manual refresh required
             this.settings.bind(setting, setting);
         });
+
+        this.settings.bind("showWeeklyChange", "showWeeklyChange", this.onHistoricalChangeDataRequested);
+        this.settings.bind("showMonthlyChange", "showMonthlyChange", this.onHistoricalChangeDataRequested);
     },
 
     getQuoteDisplaySettings(quotes) {
@@ -1463,6 +1493,10 @@ StockQuoteDesklet.prototype = {
             "currencySymbol": this.showCurrencyCode,
             "absoluteChange": this.showAbsoluteChange,
             "percentChange": this.showPercentChange,
+            "showWeeklyChange": this.showWeeklyChange,
+            "weeklyChangeType": this.weeklyChangeType,
+            "showMonthlyChange": this.showMonthlyChange,
+            "monthlyChangeType": this.monthlyChangeType,
             "colorPercentChange": this.colorPercentChange,
             "tradeTime": this.showTradeTime,
             "prePostMarketDataOption": this.includePrePostMarketDataOption,
@@ -1606,6 +1640,15 @@ StockQuoteDesklet.prototype = {
         this.onQuotesListChanged();
     },
 
+    // called when there is a change in the settings to either show or hide historical change
+    onHistoricalChangeDataRequested() {
+        this.quoteUtils.logDebug("onHistoricalChangeDataRequested");
+
+        if (this.showWeeklyChange || this.showMonthlyChange) {
+            this.onQuotesListChanged();
+        }
+    },
+
     // called when user applies network settings
     onNetworkSettingsChanged() {
         this.quoteUtils.logDebug("onNetworkSettingsChanged");
@@ -1657,28 +1700,32 @@ StockQuoteDesklet.prototype = {
         this.quoteUtils.logDebug(`fetchFinanceDataAndRender - quotes: ${quoteSymbolsArg}, network settings: ${Object.entries(networkSettings)}`);
         const _that = this;
 
-        this.quoteReader.retrieveFinanceData(quoteSymbolsArg, networkSettings, (response, instantTimer = false, dropCachedAuthParams = false) => {
-            _that.quoteUtils.logDebug(`fetchFinanceDataAndRender - response: ${response}`);
-            if (dropCachedAuthParams) {
-                _that.saveAuthorizationParameters(true);
-            }
-            try {
-                let parsedResponse = JSON.parse(response);
-                _that.lastResponse = {
-                    symbolsArgument: quoteSymbolsArg,
-                    responseResult: parsedResponse.quoteResponse.result,
-                    responseError: parsedResponse.quoteResponse.error,
-                    lastUpdated: new Date()
+        this.quoteReader.retrieveFinanceData(
+            quoteSymbolsArg,
+            networkSettings,
+            _that.getQuoteDisplaySettings([]),
+            (response, instantTimer = false, dropCachedAuthParams = false) => {
+                _that.quoteUtils.logDebug(`fetchFinanceDataAndRender - response: ${response}`);
+                if (dropCachedAuthParams) {
+                    _that.saveAuthorizationParameters(true);
                 }
+                try {
+                    let parsedResponse = JSON.parse(response);
+                    _that.lastResponse = {
+                        symbolsArgument: quoteSymbolsArg,
+                        responseResult: parsedResponse.quoteResponse.result,
+                        responseError: parsedResponse.quoteResponse.error,
+                        lastUpdated: new Date()
+                    }
 
-                _that.replaceUpdateTimer(instantTimer);
-                _that.render();
-            } catch (err) {
-                _that.quoteUtils.logException("Query response is not valid JSON", err);
-                // set current quotes list to pass check that quotes list has not changed in render()
-                _that.processFailedFetch(err, quoteSymbolsArg);
-            }
-        });
+                    _that.replaceUpdateTimer(instantTimer);
+                    _that.render();
+                } catch (err) {
+                    _that.quoteUtils.logException("Query response is not valid JSON", err);
+                    // set current quotes list to pass check that quotes list has not changed in render()
+                    _that.processFailedFetch(err, quoteSymbolsArg);
+                }
+            });
     },
 
     fetchCookieAndRender(quoteSymbolsArg, networkSettings) {

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -41,6 +41,7 @@ const YF_COOKIE_URL = "https://finance.yahoo.com/quote/%5EGSPC/options";
 const YF_CONSENT_URL = "https://consent.yahoo.com/v2/collectConsent";
 const YF_CRUMB_URL = "https://query2.finance.yahoo.com/v1/test/getcrumb";
 const YF_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote";
+const YF_HISTORY_URL = "https://query1.finance.yahoo.com/v7/finance/spark";
 const YF_QUOTE_WEBPAGE_URL = "https://finance.yahoo.com/quote/";
 const YF_QUOTE_FIELDS = "symbol,shortName,longName,currency,marketState,hasPrePostMarketData,"
     + "regularMarketTime,regularMarketPrice,regularMarketChange,regularMarketChangePercent,"
@@ -749,14 +750,61 @@ YahooFinanceQuoteReader.prototype = {
             return;
         }
 
+        //TODO needs to be chunked if there are more than 20 symbols
+        // - quoteSymbolsArg.length
+
+        //TODO need to check if this works with the after hours feature
+
+        //TODO another way to show this might be instead of percent to be the actual price value at days ago
+
+        //TODO add separate config settings to show week change and/or month change
+
+        //TODO have to update the translations
+        // - there is a command or instructions in the repo
+
+        //TODO only request history data if settings enabled
+        const quotesResponseCallback = (quoteResponse) => {
+            try {
+                const parsed = JSON.parse(quoteResponse);
+
+                if (parsed.quoteResponse && parsed.quoteResponse.error) {
+                    callback.call(_that, quoteResponse);
+                    return;
+                }
+            } catch (e) {
+                callback.call(_that, quoteResponse);
+                return;
+            }
+
+            const historyResponseMergeCallback = (historyResponse) => {
+                let finalResponse = quoteResponse;
+
+                if (historyResponse) {
+                    finalResponse = _that.mergeHistoryDataWithResults(quoteResponse, historyResponse);
+                }
+
+                callback.call(_that, finalResponse);
+            };
+
+            const historyUrl = `${YF_HISTORY_URL}?symbols=${encodeURIComponent(quoteSymbolsArg)}&range=1mo&interval=1d&crumb=${_that.authParams.crumb}`;
+
+            if (networkSettings.enableCurl) {
+                _that.retrieveFinanceDataWithCurl(historyUrl, networkSettings, historyResponseMergeCallback);
+            } else if (IS_SOUP_2) {
+                _that.retrieveFinanceDataWithSoup2(historyUrl, networkSettings, historyResponseMergeCallback);
+            } else {
+                _that.retrieveFinanceDataWithSoup3(historyUrl, networkSettings, historyResponseMergeCallback);
+            }
+        };
+
         const requestUrl = this.createYahooQueryUrl(quoteSymbolsArg, this.authParams.crumb);
 
         if (networkSettings.enableCurl) {
-            this.retrieveFinanceDataWithCurl(requestUrl, networkSettings, callback);
+            this.retrieveFinanceDataWithCurl(requestUrl, networkSettings, quotesResponseCallback);
         } else if (IS_SOUP_2) {
-            this.retrieveFinanceDataWithSoup2(requestUrl, networkSettings, callback);
+            this.retrieveFinanceDataWithSoup2(requestUrl, networkSettings, quotesResponseCallback);
         } else {
-            this.retrieveFinanceDataWithSoup3(requestUrl, networkSettings, callback);
+            this.retrieveFinanceDataWithSoup3(requestUrl, networkSettings, quotesResponseCallback);
         }
     },
 
@@ -871,6 +919,67 @@ YahooFinanceQuoteReader.prototype = {
         return queryUrl;
     },
 
+    mergeHistoryDataWithResults(quoteResponse, historyResponse) {
+        try {
+            const parsedQuotes = JSON.parse(quoteResponse);
+            const parsedHistoryData = JSON.parse(historyResponse);
+            const symbolKeyedHistoryData = {};
+
+            if (!parsedQuotes.quoteResponse || !parsedQuotes.quoteResponse.result) {
+                return quoteResponse;
+            }
+
+            parsedHistoryData.spark.result.forEach((historyDataItem) => {
+                const symbol = historyDataItem.symbol;
+
+                symbolKeyedHistoryData[symbol] = historyDataItem.response[0];
+            })
+
+            for (let quoteData of parsedQuotes.quoteResponse.result) {
+                let symbol = quoteData.symbol;
+
+                if (symbolKeyedHistoryData[symbol]) {
+                    let historyData = symbolKeyedHistoryData[symbol];
+                    quoteData.price7DaysAgo = this.pullHistoricalPriceFromData(historyData, 7);
+                    quoteData.price1MonthAgo = this.pullHistoricalPriceFromData(historyData, 30);
+                }
+            }
+
+            return JSON.stringify(parsedQuotes);
+        } catch (err) {
+            this.quoteUtils.logException("Error merging responses", err);
+            return quoteResponse;
+        }
+    },
+
+    pullHistoricalPriceFromData(historyData, daysAgo) {
+        if (
+            !historyData.timestamp ||
+            !historyData.indicators ||
+            !historyData.indicators.quote ||
+            0 === historyData.timestamp.length ||
+            0 === historyData.indicators.quote.length
+        ) {
+            return null;
+        }
+
+        const targetTimestamp = (Date.now() / 1000) - (daysAgo * 24 * 60 * 60);
+
+        let closestIndex = 0;
+        let minDiff = Math.abs(historyData.timestamp[0] - targetTimestamp);
+
+        for (let i = 1; i < historyData.timestamp.length; i++) {
+            let currentDiff = Math.abs(historyData.timestamp[i] - targetTimestamp);
+
+            if (currentDiff < minDiff) {
+                minDiff = currentDiff;
+                closestIndex = i;
+            }
+        }
+
+        return historyData.indicators.quote[0].close[closestIndex];
+    },
+
     buildErrorResponse(errorMsg) {
         return JSON.stringify(
             {
@@ -975,6 +1084,12 @@ QuotesTable.prototype = {
         if (settings.percentChange) {
             cellContents.push(this.createPercentChangeLabel(quote, settings, marketState));
         }
+
+        //TODO only if enabled
+        cellContents.push(this.createHistoricalPercentChangeLabel(quote, settings, quote.price7DaysAgo, marketState, 'W'));
+        //TODO only if enabled
+        cellContents.push(this.createHistoricalPercentChangeLabel(quote, settings, quote.price1MonthAgo, marketState, 'M'));
+
         if (settings.tradeTime) {
             cellContents.push(this.createTradeTimeLabel(quote, settings, marketState));
         }
@@ -1137,6 +1252,34 @@ QuotesTable.prototype = {
             text: this.quoteUtils.existsProperty(quote, marketChangePercentProperty)
                 ? (this.roundAmount(quote[marketChangePercentProperty], 2, settings.strictRounding) + "%")
                 : ABSENT,
+            style_class: "quotes-number",
+            style: this.buildFontStyle(settings, marketState, labelColor)
+        });
+    },
+
+    createHistoricalPercentChangeLabel(quote, settings, historicalPrice, marketState, prefix) {
+        const currentPrice = quote.regularMarketPrice;
+
+        if (!historicalPrice || !currentPrice) {
+            return new St.Label({ text: ABSENT });
+        }
+
+        const percentChange = ((currentPrice - historicalPrice) / historicalPrice) * 100;
+
+        let labelColor = settings.fontColor;
+
+        if (settings.colorPercentChange) {
+            if (percentChange > 0) {
+                labelColor = settings.uptrendChangeColor;
+            } else if (percentChange < 0) {
+                labelColor = settings.downtrendChangeColor;
+            } else {
+                labelColor = settings.unchangedTrendColor;
+            }
+        }
+
+        return new St.Label({
+            text: (prefix + this.roundAmount(percentChange, 2, settings.strictRounding) + "%"),
             style_class: "quotes-number",
             style: this.buildFontStyle(settings, marketState, labelColor)
         });

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -759,31 +759,33 @@ YahooFinanceQuoteReader.prototype = {
 
         let finalResponse = quoteResponse;
         const chunks = [];
-        const chunkResponses = [];
 
         for (let i = 0; i < allSymbols.length; i += maxSymbolsPerRequest) {
             chunks.push(allSymbols.slice(i, i + maxSymbolsPerRequest).join(","));
         }
 
-        //TODO this is called async and the script continues with 0 items in chunkResponses
-        // - there is way with the Promise to avoid this
-        // - or in the callback check when the last loop of chunks.forEach() cycles and do the merge there
-        chunks.forEach((chunkSymbols) => {
-            let historyUrl = `${YF_HISTORY_URL}?symbols=${encodeURIComponent(chunkSymbols)}&range=1mo&interval=1d&crumb=${_that.authParams.crumb}`;
-            this.sendFinanceRequestByNetworkSettings(historyUrl, networkSettings, (historyResponse) => {
-                this.quoteUtils.logDebug("====== retrieveAndMergeHistoryData - pushing chunk responses"); //TODO
-                chunkResponses.push(historyResponse);
+        const chunksPromise = new Promise((resolve) => {
+            const chunkResponses = [];
+
+            chunks.forEach((chunkSymbols) => {
+                let historyUrl = `${YF_HISTORY_URL}?symbols=${encodeURIComponent(chunkSymbols)}&range=1mo&interval=1d&crumb=${_that.authParams.crumb}`;
+                this.sendFinanceRequestByNetworkSettings(historyUrl, networkSettings, (historyResponse) => {
+                    chunkResponses.push(historyResponse);
+
+                    if (chunkResponses.length === chunks.length) {
+                        resolve(chunkResponses);
+                    }
+                });
             });
-        });
-
-        this.quoteUtils.logDebug("====== retrieveAndMergeHistoryData - chunkResponses ::: " + chunkResponses.length); //TODO
-
-        chunkResponses.forEach((chunkResponse) => {
-            this.quoteUtils.logDebug("====== retrieveAndMergeHistoryData - doing a merge"); //TODO
-            finalResponse = _that.mergeHistoryDataWithResults(finalResponse, chunkResponse);
         })
 
-        finalCallback.call(_that, finalResponse);
+        chunksPromise.then((chunkResponses) => {
+            chunkResponses.forEach((chunkResponse) => {
+                finalResponse = _that.mergeHistoryDataWithResults(finalResponse, chunkResponse);
+            })
+
+            finalCallback.call(_that, finalResponse);
+        })
     },
 
     retrieveFinanceData(quoteSymbolsArg, networkSettings, quoteDisplaySettings, callback) {
@@ -796,17 +798,14 @@ YahooFinanceQuoteReader.prototype = {
             return;
         }
 
-        //TODO need to check if this works with the after hours feature
-
-        //TODO have to update the translations
-        // - there is a command or instructions in the repo
-
         const quotesResponseCallback = (quoteResponse) => {
+            // If no historical change enabled, continue
             if (!quoteDisplaySettings.showWeeklyChange && !quoteDisplaySettings.showMonthlyChange) {
                 callback.call(_that, quoteResponse);
                 return;
             }
 
+            // Check for errors
             try {
                 const parsed = JSON.parse(quoteResponse);
 
@@ -949,15 +948,12 @@ YahooFinanceQuoteReader.prototype = {
     },
 
     mergeHistoryDataWithResults(quoteResponse, historyResponse) {
-        this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - start to merge"); //TODO
         try {
             const parsedQuotes = JSON.parse(quoteResponse);
             const parsedHistoryData = JSON.parse(historyResponse);
             const symbolKeyedHistoryData = {};
 
             if (!parsedQuotes.quoteResponse || !parsedQuotes.quoteResponse.result) {
-                this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - return no data"); //TODO
-
                 return quoteResponse;
             }
 
@@ -967,14 +963,10 @@ YahooFinanceQuoteReader.prototype = {
                 symbolKeyedHistoryData[symbol] = historyDataItem.response[0];
             })
 
-            this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - lets loop"); //TODO
             for (let quoteData of parsedQuotes.quoteResponse.result) {
                 let symbol = quoteData.symbol;
 
-                this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - symbol ::: " + symbol); //TODO
-
                 if (symbolKeyedHistoryData[symbol]) {
-                    this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - symbolKeyedHistoryData ::: " + symbol); //TODO
                     let historyData = symbolKeyedHistoryData[symbol];
                     quoteData.price7DaysAgo = this.pullHistoricalPriceFromData(historyData, 7);
                     quoteData.price1MonthAgo = this.pullHistoricalPriceFromData(historyData, 30);
@@ -1303,8 +1295,7 @@ QuotesTable.prototype = {
             return new St.Label({ text: ABSENT });
         }
 
-        const percentChange = ((currentPrice - historicalPrice) / historicalPrice) * 100;
-        const prefix = 'weekly' === labelType ? 'W' : 'M';
+        let prefix = 'weekly' === labelType ? 'W' : 'M';
         const historyChangeType = 'weekly' === labelType ? settings.weeklyChangeType : settings.monthlyChangeType;
 
         let valueToDisplay = historicalPrice;
@@ -1314,15 +1305,18 @@ QuotesTable.prototype = {
         let downtrendColor = settings.downtrendChangeColor;
 
         if ('percent' === historyChangeType) {
-            valueToDisplay = percentChange;
+            valueToDisplay = ((currentPrice - historicalPrice) / historicalPrice) * 100;
             valueForTrendCompare = 0;
+            prefix += 0 < valueToDisplay ? '+' : '';
             suffix = '%';
         } else if ('absolute' === historyChangeType) {
             valueToDisplay = currentPrice - historicalPrice;
             valueForTrendCompare = 0;
+            prefix += 0 < valueToDisplay ? '+' : '';
         }
 
         if ('market_price' === historyChangeType) {
+            // If the history price is higher, it needs to be red, because its downtrend and vice versa
             uptrendColor = settings.downtrendChangeColor;
             downtrendColor = settings.uptrendChangeColor;
         }

--- a/yfquotes@thegli/files/yfquotes@thegli/desklet.js
+++ b/yfquotes@thegli/files/yfquotes@thegli/desklet.js
@@ -740,6 +740,52 @@ YahooFinanceQuoteReader.prototype = {
         });
     },
 
+    retrieveAndMergeHistoryData(quoteSymbolsArg, quoteResponse, networkSettings, finalCallback) {
+        this.quoteUtils.logDebug("retrieveAndMergeHistoryData");
+
+        const _that = this;
+        const maxSymbolsPerRequest = 20;
+        const allSymbols = quoteSymbolsArg.split(",");
+
+        if (maxSymbolsPerRequest >= allSymbols.length) {
+            const historyUrl = `${YF_HISTORY_URL}?symbols=${encodeURIComponent(quoteSymbolsArg)}&range=1mo&interval=1d&crumb=${_that.authParams.crumb}`;
+
+            this.sendFinanceRequestByNetworkSettings(historyUrl, networkSettings, (historyResponse) => {
+                finalCallback.call(_that, _that.mergeHistoryDataWithResults(quoteResponse, historyResponse));
+            });
+
+            return;
+        }
+
+        let finalResponse = quoteResponse;
+        const chunks = [];
+        const chunkResponses = [];
+
+        for (let i = 0; i < allSymbols.length; i += maxSymbolsPerRequest) {
+            chunks.push(allSymbols.slice(i, i + maxSymbolsPerRequest).join(","));
+        }
+
+        //TODO this is called async and the script continues with 0 items in chunkResponses
+        // - there is way with the Promise to avoid this
+        // - or in the callback check when the last loop of chunks.forEach() cycles and do the merge there
+        chunks.forEach((chunkSymbols) => {
+            let historyUrl = `${YF_HISTORY_URL}?symbols=${encodeURIComponent(chunkSymbols)}&range=1mo&interval=1d&crumb=${_that.authParams.crumb}`;
+            this.sendFinanceRequestByNetworkSettings(historyUrl, networkSettings, (historyResponse) => {
+                this.quoteUtils.logDebug("====== retrieveAndMergeHistoryData - pushing chunk responses"); //TODO
+                chunkResponses.push(historyResponse);
+            });
+        });
+
+        this.quoteUtils.logDebug("====== retrieveAndMergeHistoryData - chunkResponses ::: " + chunkResponses.length); //TODO
+
+        chunkResponses.forEach((chunkResponse) => {
+            this.quoteUtils.logDebug("====== retrieveAndMergeHistoryData - doing a merge"); //TODO
+            finalResponse = _that.mergeHistoryDataWithResults(finalResponse, chunkResponse);
+        })
+
+        finalCallback.call(_that, finalResponse);
+    },
+
     retrieveFinanceData(quoteSymbolsArg, networkSettings, quoteDisplaySettings, callback) {
         this.quoteUtils.logDebug("retrieveFinanceData");
 
@@ -749,9 +795,6 @@ YahooFinanceQuoteReader.prototype = {
             callback.call(_that, _that.buildErrorResponse(_("Empty quotes list. Open settings and add some symbols.")));
             return;
         }
-
-        //TODO needs to be chunked if there are more than 20 symbols
-        // - quoteSymbolsArg.length
 
         //TODO need to check if this works with the after hours feature
 
@@ -776,31 +819,17 @@ YahooFinanceQuoteReader.prototype = {
                 return;
             }
 
-            const historyResponseMergeCallback = (historyResponse) => {
-                let finalResponse = quoteResponse;
-
-                if (historyResponse) {
-                    finalResponse = _that.mergeHistoryDataWithResults(quoteResponse, historyResponse);
-                }
-
-                callback.call(_that, finalResponse);
-            };
-
-            const historyUrl = `${YF_HISTORY_URL}?symbols=${encodeURIComponent(quoteSymbolsArg)}&range=1mo&interval=1d&crumb=${_that.authParams.crumb}`;
-
-            if (networkSettings.enableCurl) {
-                _that.retrieveFinanceDataWithCurl(historyUrl, networkSettings, historyResponseMergeCallback);
-            } else if (IS_SOUP_2) {
-                _that.retrieveFinanceDataWithSoup2(historyUrl, networkSettings, historyResponseMergeCallback);
-            } else {
-                _that.retrieveFinanceDataWithSoup3(historyUrl, networkSettings, historyResponseMergeCallback);
-            }
+            _that.retrieveAndMergeHistoryData(quoteSymbolsArg, quoteResponse, networkSettings, callback);
         };
 
         const requestUrl = this.createYahooQueryUrl(quoteSymbolsArg, this.authParams.crumb);
 
+        this.sendFinanceRequestByNetworkSettings(requestUrl, networkSettings, quotesResponseCallback);
+    },
+
+    sendFinanceRequestByNetworkSettings(requestUrl, networkSettings, callback) {
         if (networkSettings.enableCurl) {
-            this.retrieveFinanceDataWithCurl(requestUrl, networkSettings, quotesResponseCallback);
+            this.retrieveFinanceDataWithCurl(requestUrl, networkSettings, callback);
         } else if (IS_SOUP_2) {
             this.retrieveFinanceDataWithSoup2(requestUrl, networkSettings, quotesResponseCallback);
         } else {
@@ -920,12 +949,15 @@ YahooFinanceQuoteReader.prototype = {
     },
 
     mergeHistoryDataWithResults(quoteResponse, historyResponse) {
+        this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - start to merge"); //TODO
         try {
             const parsedQuotes = JSON.parse(quoteResponse);
             const parsedHistoryData = JSON.parse(historyResponse);
             const symbolKeyedHistoryData = {};
 
             if (!parsedQuotes.quoteResponse || !parsedQuotes.quoteResponse.result) {
+                this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - return no data"); //TODO
+
                 return quoteResponse;
             }
 
@@ -935,10 +967,14 @@ YahooFinanceQuoteReader.prototype = {
                 symbolKeyedHistoryData[symbol] = historyDataItem.response[0];
             })
 
+            this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - lets loop"); //TODO
             for (let quoteData of parsedQuotes.quoteResponse.result) {
                 let symbol = quoteData.symbol;
 
+                this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - symbol ::: " + symbol); //TODO
+
                 if (symbolKeyedHistoryData[symbol]) {
+                    this.quoteUtils.logDebug("====== mergeHistoryDataWithResults - symbolKeyedHistoryData ::: " + symbol); //TODO
                     let historyData = symbolKeyedHistoryData[symbol];
                     quoteData.price7DaysAgo = this.pullHistoricalPriceFromData(historyData, 7);
                     quoteData.price1MonthAgo = this.pullHistoricalPriceFromData(historyData, 30);
@@ -1271,7 +1307,6 @@ QuotesTable.prototype = {
         const prefix = 'weekly' === labelType ? 'W' : 'M';
         const historyChangeType = 'weekly' === labelType ? settings.weeklyChangeType : settings.monthlyChangeType;
 
-        //TODO maybe check createMarketPriceLabel() to add a currency
         let valueToDisplay = historicalPrice;
         let valueForTrendCompare = currentPrice;
         let suffix = '';

--- a/yfquotes@thegli/files/yfquotes@thegli/metadata.json
+++ b/yfquotes@thegli/files/yfquotes@thegli/metadata.json
@@ -3,6 +3,6 @@
     "name": "Yahoo Finance Quotes",
     "prevent-decorations": true,
     "max-instances": "10",
-    "version": "0.18.3",
+    "version": "0.18.4",
     "uuid": "yfquotes@thegli"
 }

--- a/yfquotes@thegli/files/yfquotes@thegli/po/ca.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/ca.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: yfquotes@thegli 0.13.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2025-09-29 04:46+0200\n"
 "Last-Translator: Dan <d3vf4n-linux (at) tutanota (dot) com>\n"
 "Language-Team: \n"
@@ -17,45 +17,45 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 "Llista de cotitzacions buida. Obriu la configuració i afegiu-hi alguns "
 "símbols."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "Els paràmetres d'autorització han expirat"
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "El servei de Yahoo finances no està disponible! Estat: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "No hi ha dades de cotitzacions per mostrar"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Actualitzat a les %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
@@ -64,14 +64,14 @@ msgstr ""
 "Error en recuperar el paràmetre d'autorització. No s'han pogut obtenir les "
 "dades de les cotitzacions. Estat: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 "No s'ha pogut processar el consentiment! No s'han pogut obtenir les dades de "
 "les cotitzacions. Estat: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
@@ -79,7 +79,7 @@ msgstr ""
 "No s'ha completat el processament del consentiment. No s'han pogut obtenir "
 "les dades de les cotitzacions. Estat: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -510,6 +510,53 @@ msgstr "Mostrar canvi percentual"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Mostra la variació percentual del preu de mercat (per exemple, -0.53%)"
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/da.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/da.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2026-04-06 14:20+0200\n"
 "Last-Translator: Alan Mortensen <over.tackiness223@passinbox.com>\n"
 "Language-Team: \n"
@@ -18,43 +18,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr "—"
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr "Kurslisten er tom. Åbn indstillingerne og tilføj nogle selskabskoder."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "Godkendelsesparametre er udløbet"
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Yahoo Finance er ikke tilgængelig! Status: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr "Noget gik galt, da der skulle hentes data fra Yahoo Finance. %s"
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "Der er ingen kursdata at vise"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Opdateret %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Fejl: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
@@ -62,19 +62,19 @@ msgid ""
 msgstr ""
 "Kunne ikke hente godkendelsesparameter! Kunne ikke hente kursdata. Status: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr "Samtykkebehandling mislykkedes! Kunne ikke hente kursdata. Status: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 "Samtykkebehandling ikke gennemført! Kunne ikke hente kursdata. Status: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -499,6 +499,53 @@ msgstr "Vis procentvis ændring"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Viser ændringen af markedsprisen i procent (f.eks. - 0.53%)."
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/de.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/de.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2023-08-28 16:36+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,44 +17,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr "k.A."
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 "Liste der Symbole ist leer. Öffne die Einstellungen und füge Symbole hinzu."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "Autorisierungsparameter sind abgelaufen"
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Yahoo Finance Service nicht verfügbar! Status: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr "Etwas ist schiefgelaufen während der Yahoo Finanzdaten-Abfrage. %s"
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "Keine Finanzdaten vorhanden"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Aktualisiert um %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
@@ -63,14 +63,14 @@ msgstr ""
 "Empfang von Autorisierungsparameter ist fehlgeschlagen! Finanzdaten-Abfrage "
 "nicht möglich. Status: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 "Consent-Erteilung ist fehlgeschlagen! Finanzdaten-Abfrage nicht möglich. "
 "Status: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
@@ -78,7 +78,7 @@ msgstr ""
 "Consent-Erteilung nicht abgeschlossen! Finanzdaten-Abfrage nicht möglich. "
 "Status: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -508,6 +508,53 @@ msgstr "Prozentuale Veränderung anzeigen"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Zeigt die relative Veränderung des Marktpreises an (z.B. -0,53%)"
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/es.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2026-02-21 12:03-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,44 +17,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr "N/D"
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 "Lista de cotizaciones vacía. Abra la configuración y añada algunos símbolos."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "Los parámetros de autorización han expirado"
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "El servicio de Yahoo Finanzas no está disponible: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr "Se ha producido un error al recuperar los datos de Yahoo Finance. %s"
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "No hay datos de cotizaciones para mostrar"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Actualizado en %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
@@ -63,14 +63,14 @@ msgstr ""
 "Error al recuperar el parámetro de autorización. No se han podido recuperar "
 "los datos de las cotizaciones: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 "No se ha podido procesar el consentimiento. No se han podido recuperar los "
 "datos de las cotizaciones: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
@@ -78,7 +78,7 @@ msgstr ""
 "No se ha completado el procesamiento del consentimiento. No se han podido "
 "recuperar los datos de las cotizaciones: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -512,6 +512,53 @@ msgstr "Mostrar cambio porcentual"
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr ""
 "Muestra la variación porcentual del precio de mercado (por ejemplo, -0,53%)."
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/fi.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2025-04-02 14:13+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,61 +18,61 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr "Tyhjä luettelo. Avaa asetukset ja lisää symboleja."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "Valtuutusarvot ovat vanhentuneet"
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Yahoo Finance palvelu ei ole saatavilla! Tila: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "Ei näytettäviä tietoja"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Päivitetty klo %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Virhe: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
 "Status: %s"
 msgstr "Valtuutuksen haku epäonnistui! Tietoja ei voi noutaa. Tila: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr "Suostumuksen käsittely epäonnistui! Tietoja ei voi noutaa. Tila: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
 msgstr "Suostumusta ei ole suoritettu loppuun! Tietoja ei voi noutaa. Tila: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -495,6 +495,53 @@ msgstr "Näytä muutosposentti"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Tuo näkyviin markkinahinnan prosentuaalisen muutoksen (esim. -0.53 %)."
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/hu.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/hu.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: yfquotes@thegli 0.13.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2026-02-26 07:46+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,45 +18,45 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.8\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr "N/A"
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 "Üres idézetek listája. Nyissa meg a beállításokat, és adjon hozzá néhány "
 "szimbólumot."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "Az engedélyezési paraméterek lejártak"
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "A Yahoo Finance szolgáltatás pillanatnyilag nem érhető el. Állapot: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr "Hiba történt a Yahoo Finance adatainak lekérésekor. %s"
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "Nincs megjeleníthető idézet adat"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Frissítve: %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Hiba: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
@@ -65,14 +65,14 @@ msgstr ""
 "Nem sikerült lekérni az engedélyezési paramétert. Nem sikerült letölteni a "
 "pénzügyi adatokat. Állapot: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 "Az engedélykezelés nem sikerült. Nem sikerült letölteni a pénzügyi adatokat. "
 "Állapot: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
@@ -80,7 +80,7 @@ msgstr ""
 "Az engedélykezelés nem fejeződött be. Nem sikerült letölteni a pénzügyi "
 "adatokat. Állapot: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -511,6 +511,53 @@ msgstr "Százalékos változás megjelenítése"
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr ""
 "Piaci ár változásának százalékos értékének megjelenítése (például: -0,53%)."
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/it.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/it.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2025-08-26 22:12+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,43 +18,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr "Lista quotazioni vuota. Apri le impostazioni e aggiungi dei simboli."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "I parametri di autorizzazione sono scaduti"
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Il servizio Yahoo Finance non è disponibile! Stato: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "Nessun dato delle quotazioni da mostrare"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Aggiornato al %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Errore: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
@@ -63,14 +63,14 @@ msgstr ""
 "Impossibile recuperare il parametro di autorizzazione! Impossibile "
 "recuperare i dati delle quotazioni. Stato: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 "Elaborazione del consenso non riuscita! Impossibile recuperare i dati delle "
 "quotazioni. Stato: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
@@ -78,7 +78,7 @@ msgstr ""
 "Elaborazione del consenso non completata! Impossibile recuperare i dati "
 "delle quotazioni. Stato: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -510,6 +510,53 @@ msgstr "Mostra variazione percentuale"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Mostra la variazione percentuale del prezzo di mercato (es. -0,53%)"
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/ko.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/ko.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Yahoo Finance Quotes Desklet\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,61 +17,61 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr ""
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Yahoo Finance 서비스를 사용할 수 없습니다! %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr ""
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "업데이트 날짜 %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "오류: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
 "Status: %s"
 msgstr ""
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -473,6 +473,53 @@ msgstr "변화율 표시"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "시장 가격의 백분율 변화를 표시합니다 (예 : + 0.53 %)."
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/nl.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: yfquotes@thegli 0.11.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2025-08-25 18:25+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,43 +16,43 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr "Lege lijst van koersen. Open instellingen en voeg wat symbolen toe."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "Autorisatieparameters zijn verlopen."
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Yahoo Finance service niet beschikbaar! Status: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "Geen citatendata om weer te geven"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Bijgewerkt om %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
@@ -61,14 +61,14 @@ msgstr ""
 "Kan autorisatieparameter niet ophalen! Kan geen gegevens voor koersen "
 "ophalen. Status: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 "Toestemming verwerking mislukt! Kan geen gegevens voor koersen ophalen. "
 "Status: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
@@ -76,7 +76,7 @@ msgstr ""
 "Toestemming verwerking niet voltooid! Kan geen gegevens voor koersen "
 "ophalen. Status: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -503,6 +503,53 @@ msgstr "Toon procentuele verandering"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Toon de procentuele verandering van de marktprijs (bijv. -0,53%)"
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/pt_BR.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/pt_BR.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2021-09-30 13:34-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -18,61 +18,61 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr ""
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "O serviço de finanças do Yahoo não está disponível! %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr ""
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Atualizado em %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
 "Status: %s"
 msgstr ""
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -483,6 +483,53 @@ msgstr "Mostrar a porcentagem da mudança"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Exibe a variação percentual do preço da ação (por exemplo: -0,53%)."
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/ro.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/ro.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: 2023-07-19 22:16+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,61 +18,61 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
 "20)) ? 1 : 2;\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr ""
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Serviciul Yahoo Finance nu este disponibil! %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr ""
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Actualizat la %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Eroare: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
 "Status: %s"
 msgstr ""
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -482,6 +482,53 @@ msgstr "Afișează modificarea procentuală"
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr ""
 "Afișează modificarea procentuală a prețului de piață (de exemplu, -0,53%)."
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/ru.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/ru.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,61 +17,61 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr ""
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Сервис Yahoo Finance не доступен! %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr ""
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Обновлено в %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Ошибка: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
 "Status: %s"
 msgstr ""
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -483,6 +483,53 @@ msgstr "Показывать изменения в процентах"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Отображение изменений рыночной цены в процентах (например, -0.53%)."
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/vi.po
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/vi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: yfquotes@thegli 0.17.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -17,43 +17,43 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr "Danh sách báo giá trống. Mở cài đặt và thêm một số ký hiệu."
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr "Tham số ủy quyền đã hết hạn"
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr "Dịch vụ Yahoo Finance không khả dụng! Trạng thái: %s"
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr "Không có dữ liệu báo giá để hiển thị"
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr "Cập nhật lúc %s"
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr "Lỗi: %s"
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
@@ -62,19 +62,19 @@ msgstr ""
 "Không thể truy xuất tham số ủy quyền! Không thể tải dữ liệu báo giá. Trạng "
 "thái: %s"
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr "Xử lý đồng ý thất bại! Không thể tải dữ liệu báo giá. Trạng thái: %s"
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 "Xử lý đồng ý chưa hoàn tất! Không thể tải dữ liệu báo giá. Trạng thái: %s"
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -496,6 +496,53 @@ msgstr "Hiển thị phần trăm thay đổi"
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
 msgstr "Hiển thị phần trăm thay đổi của giá thị trường (ví dụ: -0.53%)"
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
+msgstr ""
 
 #. settings-schema.json->colorPercentChange->description
 msgid "Use trend colors for percent change"

--- a/yfquotes@thegli/files/yfquotes@thegli/po/yfquotes@thegli.pot
+++ b/yfquotes@thegli/files/yfquotes@thegli/po/yfquotes@thegli.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: yfquotes@thegli 0.18.3\n"
+"Project-Id-Version: yfquotes@thegli 0.18.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-desklets/"
 "issues\n"
-"POT-Creation-Date: 2026-03-05 21:41+0100\n"
+"POT-Creation-Date: 2026-06-17 20:35+0300\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,61 +17,61 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. desklet.js:99
+#. desklet.js:100
 msgid "N/A"
 msgstr ""
 
-#. desklet.js:748
+#. desklet.js:797
 msgid "Empty quotes list. Open settings and add some symbols."
 msgstr ""
 
-#. desklet.js:797 desklet.js:830 desklet.js:860
+#. desklet.js:873 desklet.js:906 desklet.js:936
 msgid "Authorization parameters have expired"
 msgstr ""
 
-#. desklet.js:800 desklet.js:833 desklet.js:863
+#. desklet.js:876 desklet.js:909 desklet.js:939
 #, javascript-format
 msgid "Yahoo Finance service not available! Status: %s"
 msgstr ""
 
-#. desklet.js:804
+#. desklet.js:880
 #, javascript-format
 msgid "Something went wrong retrieving Yahoo Finance data. %s"
 msgstr ""
 
-#. desklet.js:1269
+#. desklet.js:1467
 msgid "No quotes data to display"
 msgstr ""
 
-#. desklet.js:1363
+#. desklet.js:1569
 #, javascript-format
 msgid "Updated at %s"
 msgstr ""
 
-#. desklet.js:1395
+#. desklet.js:1601
 #, javascript-format
 msgid "Error: %s"
 msgstr ""
 
-#. desklet.js:1554
+#. desklet.js:1773
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization parameter! Unable to fetch quotes data. "
 "Status: %s"
 msgstr ""
 
-#. desklet.js:1585
+#. desklet.js:1804
 #, javascript-format
 msgid "Consent processing failed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1591
+#. desklet.js:1810
 #, javascript-format
 msgid ""
 "Consent processing not completed! Unable to fetch quotes data. Status: %s"
 msgstr ""
 
-#. desklet.js:1627
+#. desklet.js:1846
 #, javascript-format
 msgid ""
 "Failed to retrieve authorization crumb! Unable to fetch quotes data. Status: "
@@ -468,6 +468,53 @@ msgstr ""
 
 #. settings-schema.json->showPercentChange->tooltip
 msgid "Display the percent change of the market price (eg. -0.53%)"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->description
+msgid "Show weekly change"
+msgstr ""
+
+#. settings-schema.json->showWeeklyChange->tooltip
+msgid "Display the change of the market price from 7 days ago"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Percent change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Absolute change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->options
+#. settings-schema.json->monthlyChangeType->options
+msgid "Market price"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->description
+msgid "Type of weekly change"
+msgstr ""
+
+#. settings-schema.json->weeklyChangeType->tooltip
+msgid "What type should be the value for the weekly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->description
+msgid "Show monthly change"
+msgstr ""
+
+#. settings-schema.json->showMonthlyChange->tooltip
+msgid "Display the change of the market price from 1 month ago"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->description
+msgid "Type of monthly change"
+msgstr ""
+
+#. settings-schema.json->monthlyChangeType->tooltip
+msgid "What type should be the value for the monthly change"
 msgstr ""
 
 #. settings-schema.json->colorPercentChange->description

--- a/yfquotes@thegli/files/yfquotes@thegli/settings-schema.json
+++ b/yfquotes@thegli/files/yfquotes@thegli/settings-schema.json
@@ -103,6 +103,10 @@
                 "showChangeIcon",
                 "showAbsoluteChange",
                 "showPercentChange",
+                "showWeeklyChange",
+                "weeklyChangeType",
+                "showMonthlyChange",
+                "monthlyChangeType",
                 "colorPercentChange"
             ]
         },
@@ -425,6 +429,42 @@
         "default": true,
         "description": "Show percent change",
         "tooltip": "Display the percent change of the market price (eg. -0.53%)"
+    },
+    "showWeeklyChange": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Show weekly change",
+        "tooltip": "Display the change of the market price from 7 days ago"
+    },
+    "weeklyChangeType": {
+        "type": "radiogroup",
+        "default": "percent",
+        "options": {
+            "Percent change": "percent",
+            "Absolute change": "absolute",
+            "Market price": "market_price"
+        },
+        "description": "Type of weekly change",
+        "tooltip": "What type should be the value for the weekly change",
+        "dependency": "showWeeklyChange"
+    },
+    "showMonthlyChange": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Show monthly change",
+        "tooltip": "Display the change of the market price from 1 month ago"
+    },
+    "monthlyChangeType": {
+        "type": "radiogroup",
+        "default": "percent",
+        "options": {
+            "Percent change": "percent",
+            "Absolute change": "absolute",
+            "Market price": "market_price"
+        },
+        "description": "Type of monthly change",
+        "tooltip": "What type should be the value for the monthly change",
+        "dependency": "showMonthlyChange"
     },
     "colorPercentChange": {
         "type": "checkbox",


### PR DESCRIPTION
This PR adds options to enable extra columns for weekly change and monthly change of each stock. The display value can be configured to be 1 of 3 options: percent change, absolute change (difference) or just display the market price from a week/month ago.

The data required for this is fetched with a single request if the tickers are up to 20, if they are more than 20, the requests are chunked to 20 tickers each, which is the limit forced by YF. 

If one of the weekly or monthly options are enabled, the data is merged to the existing quotes data argument and then used when the labels are getting created. I think merging the data introduces the least amount of changes to existing methods and doesn't require any new arguments being passed around.

<img width="446" height="426" alt="image" src="https://github.com/user-attachments/assets/9ed71875-4da8-404b-af4b-358bae14d180" />
<img width="448" height="428" alt="image" src="https://github.com/user-attachments/assets/4c619b97-d7fd-49a4-bee4-0f45b338968d" />
<img width="788" height="845" alt="image" src="https://github.com/user-attachments/assets/9eed2dd3-5270-4343-a028-cf18e9cab55f" />
